### PR TITLE
fix code that removes certain items from localStorage

### DIFF
--- a/files/end.js
+++ b/files/end.js
@@ -78,7 +78,7 @@
           localStorage.removeItem('_remoteStorageAuthAddress');
           localStorage.removeItem('_remoteStorageOauthToken');
           localStorage.removeItem('_remoteStorageDirties');
-          localStorage.removeItem('remoteStorageIndex');debugger
+          localStorage.removeItem('remoteStorageIndex');
           var keysToRemove = [];
           for(var i=0; i<localStorage.length; i++) {
             if(localStorage.key(i).substring(0,15)=='_remoteStorage_') {


### PR DESCRIPTION
I started playing with remoteStorage and I think I found a bug in the code that removes items in a for loop. The index numbers of the storage are decreased in the loop by removing items and thus items are skipped.

Please check.
