### PR TITLE
small documentation bug

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,9 +20,9 @@
 
     <div id="remotestorage-connect"></div>
 
-#### load the 'tasks' module,
+#### claim access to the 'tasks' module,
 
-    remoteStorage.loadModule('tasks', 'rw');
+    remoteStorage.claimAccess('tasks', 'rw');
 
 #### and after you have loaded all the modules you will be using, but still in your app's onload function,
 #### add a call to put the 'connect your remote storage' UI into that div, 


### PR DESCRIPTION
I found a small bug in the documentation:
the deprecated loadModule was used instead of claimAccess.
