### PR TITLE
Update gitignore with server-state dir of example server 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,4 @@ doc/code/
 doc/config/
 *.log
 server/server-state
+server-state


### PR DESCRIPTION
It was already in there, but when I started the example server last time, it added the directory to the root, not the one that was specified in gitignore.
