### PR TITLE
make remotestorage.io link open in new tab, fix #237

### DIFF
--- a/src/lib/i18n/locales/en.js
+++ b/src/lib/i18n/locales/en.js
@@ -15,7 +15,7 @@ define([], function() {
         'offline': '<strong>{userAddress}</strong> (offline)',
         'unauthorized': 'Unauthorized! Click to reconnect.',
         'redirecting': 'Redirecting to <strong>{hostName}</strong>',
-        'typing-hint': 'This app allows you to use your own storage! Find more info on <a href="http://remotestorage.io/">remotestorage.io</a>',
+        'typing-hint': 'This app allows you to use your own storage! Find more info on <a href="http://remotestorage.io/" target="_blank">remotestorage.io</a>',
         'last-synced': '{t}',
         'webfinger-failed': "{message}",
         'webfinger-error-no-at': "There is no @-sign in the user address.",


### PR DESCRIPTION
So you don’t get thrown out of the app. Also makes it compliant to the Firefox Marketplace guidelines. Fixes #237 
cc @michielbdejong @nilclass
