### PR TITLE
launching with /#remotestorage=a@b broken in 0.7.2?

### DIFF
--- a/src/lib/widget.js
+++ b/src/lib/widget.js
@@ -189,6 +189,11 @@ define([
     // Query parameter: remotestorage
     if(params.remotestorage) {
       view.setUserAddress(params.remotestorage);
+      setTimeout(function() {
+        if(wireClient.getState() !== 'connected') {
+          connectStorage(params.remotestorage);
+        }
+      }, 0);
     } else {
       var userAddress = settings.get('userAddress');
       if(userAddress) {


### PR DESCRIPTION
i can see it gets to the point where processParams calls view.setUserAddress, but it somehow doesn't initiate the webfinger lookup after that
