### PR TITLE
more understandable input field label, fix #317

### DIFF
--- a/src/lib/widget/default.js
+++ b/src/lib/widget/default.js
@@ -407,7 +407,7 @@ define(['../util', '../assets', '../i18n'], function(util, assets, i18n) {
     elements.connectForm = cEl('form');
     elements.connectForm.setAttribute('novalidate', '');
     elements.connectForm.innerHTML = [
-      '<input type="email" placeholder="user@host" name="userAddress" novalidate>',
+      '<input type="email" placeholder="user@provider.com" name="userAddress" novalidate>',
       '<button class="connect" value="" name="connect">'
     ].join('');
     var connectIcon = cEl('img');


### PR DESCRIPTION
Changes the text field placeholder from »user@host« to »user@provider.com«. More understandable, and fixes #317.
