### PR TITLE
Construct query component according to draft-ietf-appsawg-webfinger-14

### DIFF
--- a/src/lib/webfinger.js
+++ b/src/lib/webfinger.js
@@ -223,7 +223,7 @@ define(
             return promise.reject(error);
           }
         }
-        var query = '?resource=acct:' + encodeURIComponent(userAddress);
+        var query = '?resource=' + encodeURIComponent('acct:' + userAddress);
         var addresses = [
           '://' + hostname + '/.well-known/webfinger' + query,
           '://' + hostname + '/.well-known/host-meta.json' + query,


### PR DESCRIPTION
I'm working on a [WebFinger resource for nginx](https://gist.github.com/agrueneberg/5693181) and noticed that remotestorage.js does not encode the query component according to [Section 4.1 of draft-ietf-appsawg-webfinger-14](https://tools.ietf.org/html/draft-ietf-appsawg-webfinger-14#section-4.1):

> To construct the query component, the client performs the following
> steps.  First, each parameter value is percent-encoded, as per
> Section 2.1 of RFC 3986.  The encoding is done to conform to the
> query production in Section 3.4 of that specification, with the
> addition that any instances of the "=" and "&" characters within the
> parameter values are also percent-encoded.  **Next, the client
> constructs a string to be placed in the query component by
> concatenating the name of the first parameter together with an equal
> sign ("=") and the percent-encoded parameter value.**  For any
> subsequent parameters, the client appends an ampersand ("&") to the
> string, the name of the next parameter, an equal sign, and the
> parameter value.  The client MUST NOT insert any spaces while
> constructing the string.  The order in which the client places each
> attribute-and-value pair within the query component does not matter
> in the interpretation of the query component.

Unfortunately nginx does not decode URL parameters, so for me this little change means the difference between fetching the file `acct:bob%40example.com.json` or `acct%3Abob%40example.com.json`.
