### PR TITLE
BaseClient~set calls sync.set instead of talking to store directly now. ...

### DIFF
--- a/src/lib/baseClient.js
+++ b/src/lib/baseClient.js
@@ -114,7 +114,7 @@ define([
           newValue: value,
           path: absPath
         };
-        return store.setNodeData(absPath, value, true, undefined, mimeType);
+        return sync.set(absPath, { data: value, mimeType: mimeType });
       }).then(function() {
         fireModuleEvent('change', moduleName, changeEvent);
         if(moduleName !== 'root') {

--- a/src/lib/sync.js
+++ b/src/lib/sync.js
@@ -767,7 +767,13 @@ define([
       }
     },
 
-    set: function(path) {},
+    set: function(path, node) {
+      if(caching.cachePath(path)) {
+        return store.setNodeData(path, node.data, true, undefined, node.mimeType);
+      } else {
+        return remoteAdapter.set(path, node);
+      }
+    },
 
     remove: function(path) {
       if(caching.cachePath(path)) {


### PR DESCRIPTION
...That way caching are evaluated in a central place. (previously storing directly to remote was broken)
