### PR TITLE
Fixed the profile never being parsed and added handling of profiles without a links section.

### DIFF
--- a/src/discover.js
+++ b/src/discover.js
@@ -34,13 +34,21 @@ q(function(global) {
       xhr.onload = function() {
         if(xhr.status != 200) return tryOne();
         var profile;
+	  
         try {
-          JSON.parse(xhr.responseText);
+          profile = JSON.parse(xhr.responseText);
         } catch(e) {
           RemoteStorage.log("Failed to parse profile ", xhr.responseText, e);
           tryOne();
           return;
         }
+
+        if (!profile.links) {
+          RemoteStorage.log("profile has no links section ", JSON.stringify(profile));
+          tryOne();
+          return;
+        }
+
         var link;
         profile.links.forEach(function(l) {
           if(l.rel == 'remotestorage') {


### PR DESCRIPTION
This fixes the fix for issue #378 and prevent failure when encountering webfinger profiles missing a `links` section.
