### PR TITLE
On 304, promise is never fulfilled

### DIFF
--- a/src/sync.js
+++ b/src/sync.js
@@ -120,7 +120,7 @@
           // do nothing.
           promise.fulfill();
         }
-      }, promise.fulfill).then(undefined, promise.reject);
+      }, promise.reject).then(undefined, promise.reject);
     }).then(undefined, promise.reject);
     return promise;
   }

--- a/src/wireclient.js
+++ b/src/wireclient.js
@@ -65,7 +65,7 @@
       return false;
     };
   }
-  
+
   function request(method, uri, token, headers, body, getEtag, fakeRevision) {
     if((method == 'PUT' || method == 'DELETE') && uri[uri.length - 1] == '/') {
       throw "Don't " + method + " on directories!";
@@ -302,11 +302,16 @@
     xhr.onerror = function(error) {
       if(timedOut) return;
       clearTimeout(timer);
-      callback(error);
+      if (xhr.status === 0 && xhr.statusText === "") {
+        xhr.status = 304;
+        callback(null, xhr);
+      } else {
+        callback(error);
+      }
     };
 
     var body = options.body;
-    
+
     if(typeof(body) == 'object') {
       if(isArrayBufferView(body)) { /* alright. */ }
       else if(body instanceof ArrayBuffer) {


### PR DESCRIPTION
When remote content is up to date, server response with status 304, which trigger the xhr.on error.
In this case, the promise is never fulfilled and synchronize fails.

This is a edge case because, at least in Firefox, I haven't found any way in xhr.onerror to distinguish between 304, which should fulfill the promise, and real errors, which should reject the promise.

I use this little hack for some weeks now and it seems to work.
