### PR TITLE
Header fixes

### DIFF
--- a/src/wireclient.js
+++ b/src/wireclient.js
@@ -67,7 +67,7 @@
       return false;
     };
   }
-  
+
   function request(method, uri, token, headers, body, getEtag, fakeRevision) {
     if((method == 'PUT' || method == 'DELETE') && uri[uri.length - 1] == '/') {
       throw "Don't " + method + " on directories!";
@@ -188,7 +188,7 @@
      *   // -> 'draft-dejong-remotestorage-01'
      */
 
-    
+
     configure: function(userAddress, href, storageApi, token) {
       if(typeof(userAddress) !== 'undefined') this.userAddress = userAddress;
       if(typeof(href) !== 'undefined') this.href = href;
@@ -277,12 +277,13 @@
     'delete': function(path, options) {
       if(! this.connected) throw new Error("not connected (path: " + path + ")");
       if(!options) options = {};
+      var headers = {};
       if(this.supportsRevs) {
         if(options.ifMatch)
           headers['If-Match'] = options.ifMatch;
       }
       return request('DELETE', this.href + cleanPath(path), this.token,
-                     headers ,
+                     headers,
                      undefined, this.supportsRevs);
     }
 
@@ -325,7 +326,7 @@
     };
 
     var body = options.body;
-    
+
     if(typeof(body) == 'object') {
       if(isArrayBufferView(body)) { /* alright. */ }
       else if(body instanceof ArrayBuffer) {

--- a/test/unit/wireclient-suite.js
+++ b/test/unit/wireclient-suite.js
@@ -344,6 +344,17 @@ define(['requirejs'], function(requirejs, undefined) {
       },
 
       {
+        desc: "#delete doesn't set the 'If-Match' when revisions are supported and no rev given",
+        run: function(env, test) {
+          env.connectedClient.configure(undefined, undefined, 'draft-dejong-remotestorage-01');
+          env.connectedClient.delete('/foo/bar');
+          var request = XMLHttpRequest.instances.shift();
+          var hasIfMatchHeader = request._headers.hasOwnProperty('If-Match');
+          test.assert(hasIfMatchHeader, false);
+        }
+      },
+
+      {
         desc: "WireClient destroys the bearer token after Unauthorized Error",
         run: function(env, test){
           env.rs._emit('error', new RemoteStorage.Unauthorized());
@@ -405,7 +416,6 @@ define(['requirejs'], function(requirejs, undefined) {
           req._onload();
         }
       },
-
 
       {
         desc: "404 responses discard the body altogether",


### PR DESCRIPTION
The tests I added check that the 'If-Match' and 'If-None-Match' are really not set at all when no revision is given. The previous test for the GET request didn't fail when the 'If-None-Match' header was set to `undefined`.
