### PR TITLE
Re-add test for storeObject method

### DIFF
--- a/test/unit/baseclient-suite.js
+++ b/test/unit/baseclient-suite.js
@@ -26,7 +26,7 @@ define(['requirejs'], function(requirejs, undefined) {
         }
       };
       require('./src/eventhandling');
-      if(global.rs_eventhandling) {
+      if (global.rs_eventhandling) {
         RemoteStorage.eventHandling = global.rs_eventhandling;
       } else {
         global.rs_eventhandling = RemoteStorage.eventHandling;
@@ -34,10 +34,10 @@ define(['requirejs'], function(requirejs, undefined) {
       require('./lib/Math.uuid');
       require('./src/baseclient');
       require('./src/baseclient/types');
-      if(global.rs_types) {
-        RemoteStorage.BaseClient.Types = global.rs_types
+      if (global.rs_types) {
+        RemoteStorage.BaseClient.Types = global.rs_types;
       } else {
-          global.rs_types = RemoteStorage.BaseClient.Types
+        global.rs_types = RemoteStorage.BaseClient.Types;
       }
       test.done();
     },

--- a/test/unit/baseclient/types-suite.js
+++ b/test/unit/baseclient/types-suite.js
@@ -12,10 +12,10 @@ define([], function() {
       RemoteStorage.BaseClient = function() {};
       RemoteStorage.BaseClient.prototype.extend = function() {};
       require('./src/baseclient/types');
-      if(global.rs_types) {
-        RemoteStorage.BaseClient.Types = global.rs_types
+      if (global.rs_types) {
+        RemoteStorage.BaseClient.Types = global.rs_types;
       } else {
-          global.rs_types = RemoteStorage.BaseClient.Types
+        global.rs_types = RemoteStorage.BaseClient.Types;
       }
       test.done();
     },


### PR DESCRIPTION
Someone left the `storeObject` test commented in the test suite.

We just added the missing dependency that made it fail (baseclient/types) and fixed the test itself. However, something is wrong with the requiring of modules, so the baseclient suite now fails when running all test at once, and the suite is only green when run on its own.

@silverbucket Could you help us fix this, please? Or someone else, who knows more about teste and/or the rs.js test suite?
