### PR TITLE
Install uglify-js as local node module to use in build script

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,6 +3,7 @@ DOC_BIN        = naturaldocs
 DOC_DIR        = ./doc/code
 DOC_CONFIG_DIR = ./doc/config
 DOC_CUSTOM_CSS = custom-1
+UGLIFY_BIN     = ./node_modules/.bin/uglifyjs
 SOURCE_DIR     = ./src
 ASSETS_DIR     = ./assets
 ASSETS_OUT     = $(SOURCE_DIR)/assets.js
@@ -42,7 +43,7 @@ compile-assets: $(ASSETS_OUT)
 
 %.min.js: %.js
 #	uglifyjs $< -o $@ --mangle --wrap --export-all
-	uglifyjs -o $@ $<
+	$(UGLIFY_BIN) -o $@ $<
 	mv $@ $@.tmp
 	head -n1 $< > $@
 	cat $@.tmp >> $@

--- a/README.md
+++ b/README.md
@@ -56,7 +56,8 @@ Use the teste executable in order to test single files, like so e.g.:
 
 ### How to build
 
-Install node-uglify and naturaldocs first.
+Make sure you have [NaturalDocs](http://www.naturaldocs.org/) installed
+on you system.
 
 Display the available build tasks:
 

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
   "homepage": "http://remotestorage.io",
   "devDependencies": {
     "teste": "*",
-    "uglifyjs": "*"
+    "uglify-js": "2.4.x"
   },
   "scripts": {
     "test": "node_modules/.bin/teste"


### PR DESCRIPTION
This makes uglify-js installable via `npm install`, removing the need to install it globally to be able to run the build script.
