### PR TITLE
Fix setSyncInterval refs #461 #462

### DIFF
--- a/src/sync.js
+++ b/src/sync.js
@@ -248,36 +248,37 @@
       return synchronize(remote, local, path, {
         data: false
       });
-    },
-    /**
-     * Method: getSyncInterval
-     *
-     * Get the value of the sync interval
-     *
-     * Returns a number of milliseconds
-     *
-     */
-    getSyncInterval: function() {
-      return syncInterval;
-    },
-    /**
-     * Method: setSyncInterval
-     *
-     * Set the value of the sync interval
-     *
-     * Parameters:
-     *   interval - sync interval in milliseconds
-     *
-     */
-    setSyncInterval: function(interval) {
-      if(typeof(interval) != 'number') {
-        throw interval + " is not a valid sync interval";
-      }
-      syncInterval = parseInt(interval, 10);
-      if (this._syncTimer) {
-        this.stopSync();
-        this._syncTimer = setTimeout(this.syncCycle.bind(this), interval);
-      }
+    }
+  };
+
+  /**
+   * Method: getSyncInterval
+   *
+   * Get the value of the sync interval when application is in the foreground
+   *
+   * Returns a number of milliseconds
+   *
+   */
+  RemoteStorage.prototype.getSyncInterval = function() {
+    return syncInterval;
+  };
+  /**
+   * Method: setSyncInterval
+   *
+   * Set the value of the sync interval when application is in the foreground
+   *
+   * Parameters:
+   *   interval - sync interval in milliseconds
+   *
+   */
+  RemoteStorage.prototype.setSyncInterval = function(interval) {
+    if(typeof(interval) != 'number') {
+      throw interval + " is not a valid sync interval";
+    }
+    syncInterval = parseInt(interval, 10);
+    if (this._syncTimer) {
+      this.stopSync();
+      this._syncTimer = setTimeout(this.syncCycle.bind(this), interval);
     }
   };
 

--- a/test/unit/sync-suite.js
+++ b/test/unit/sync-suite.js
@@ -16,6 +16,7 @@ define(['requirejs', 'fs'], function(requirejs, fs, undefined) {
     },
 
     beforeEach: function(env, test) {
+      env.rs = new RemoteStorage();
       test.done();
     },
 
@@ -24,15 +25,15 @@ define(['requirejs', 'fs'], function(requirejs, fs, undefined) {
       {
         desc: "Default value ",
         run: function(env, test) {
-          test.assert(RemoteStorage.Sync.getSyncInterval(), 10000);
+          test.assert(env.rs.getSyncInterval(), 10000);
         }
       },
 
       {
         desc: "Update value",
         run: function(env, test) {
-          RemoteStorage.Sync.setSyncInterval(60000);
-          test.assert(RemoteStorage.Sync.getSyncInterval(), 60000);
+          env.rs.setSyncInterval(60000);
+          test.assert(env.rs.getSyncInterval(), 60000);
         }
       },
 
@@ -40,7 +41,7 @@ define(['requirejs', 'fs'], function(requirejs, fs, undefined) {
         desc: "#set a wrong value throws an error",
         run: function(env, test) {
           try {
-            RemoteStorage.Sync.setSyncInterval('60000');
+            env.rs.setSyncInterval('60000');
             test.result(false, "setSyncInterval() didn't fail");
           } catch(e) {
             test.result(true);
@@ -52,3 +53,4 @@ define(['requirejs', 'fs'], function(requirejs, fs, undefined) {
 
   return suites;
 });
+


### PR DESCRIPTION
When updating the sync interval, we need to stop the current sync timer and start a new one. `stopSync` and  `_syncTimer' are methods and properties of`RemoteStorage`, so`setSyncInterval`also need to be on`RemoteStorage`and not on`RemoteStorage.Sync`.
Refs #461 and #462
