### PR TITLE
Add JSHint config

### DIFF
--- a/.jshintrc
+++ b/.jshintrc
@@ -1,0 +1,58 @@
+{
+    "passfail"      : false,  // Stop on first error.
+
+    // Predefined globals whom JSHint will ignore
+    "browser"       : true,   // Standard browser globals e.g. `window`, `document`.
+    "node"          : true,
+
+    // Extra globals
+    "predef"        : [
+        "RS",
+        "RemoteStorage",
+        "remoteStorage"
+    ],
+
+    // Development
+    "debug"         : false,  // Allow debugger statements e.g. browser breakpoints.
+    "devel"         : true,   // Allow development statements e.g. `console.log();`.
+
+    // EcmaScript 5
+    "es5"           : true,   // Allow EcmaScript 5 syntax.
+    "strict"        : false,  // Require `use strict` pragma in every file.
+    "globalstrict"  : true,   // Allow global "use strict" (also enables 'strict').
+
+    // The Good Parts
+    "asi"           : false,  // Tolerate Automatic Semicolon Insertion (no semicolons).
+    "laxbreak"      : true,   // Tolerate unsafe line breaks e.g. `return [\n] x` without semicolons.
+    "bitwise"       : true,   // Prohibit bitwise operators (&, |, ^, etc.).
+    "boss"          : false,  // Tolerate assignments inside if, for & while. Usually conditions & loops are for comparison, not assignments.
+    "curly"         : true,   // Require {} for every new block or scope.
+    "eqeqeq"        : true,   // Require triple equals i.e. `===`.
+    "eqnull"        : false,  // Tolerate use of `== null`.
+    "evil"          : false,  // Tolerate use of `eval`.
+    "expr"          : false,  // Tolerate `ExpressionStatement` as Programs.
+    "forin"         : false,  // Tolerate `for in` loops without `hasOwnPrototype`.
+    "immed"         : true,   // Require immediate invocations to be wrapped in parens e.g. `( function(){}() );`
+    "latedef"       : false,  // Prohibit variable use before definition.
+    "loopfunc"      : false,  // Allow functions to be defined within loops.
+    "noarg"         : true,   // Prohibit use of `arguments.caller` and `arguments.callee`.
+    "regexp"        : true,   // Prohibit `.` and `[^...]` in regular expressions.
+    "regexdash"     : false,  // Tolerate unescaped last dash i.e. `[-...]`.
+    "scripturl"     : true,   // Tolerate script-targeted URLs.
+    "shadow"        : false,  // Allows re-define variables later in code e.g. `var x=1; x=2;`.
+    "supernew"      : false,  // Tolerate `new function () { ... };` and `new Object;`.
+    "undef"         : false,  // Require all non-global variables be declared before they are used.
+
+    // Styling
+    "newcap"        : true,   // Require capitalization of all constructor functions e.g. `new F()`.
+    "noempty"       : true,   // Prohibit use of empty blocks.
+    "nonew"         : true,   // Prohibit use of constructors for side-effects.
+    "nomen"         : false,  // Prohibit use of initial or trailing underbars in names.
+    "onevar"        : false,  // Allow only one `var` statement per function.
+    "plusplus"      : false,  // Prohibit use of `++` & `--`.
+    "sub"           : true,   // Tolerate all forms of subscript notation besides dot notation e.g. `dict['key']` instead of `dict.key`.
+    "trailing"      : true,   // Prohibit trailing whitespaces.
+    "white"         : false,  // Check against strict whitespace and indentation rules.
+    "indent"        : 2,
+    "multistr"      : true
+}


### PR DESCRIPTION
Using JSHint makes it easy for everyone to follow common code quality and formatting rules. This config is also very similar to what the [CodeClimate](https://codeclimate.com/github/remotestorage/remotestorage.js) linter will consider clean code.

Feel free to discuss these rules, although we can also do that later in new PRs. I'd rather have something as soon as possible and then improve it over time.

If you need help setting up JSHint in your editor, you should find plenty of resources via your favorite search engine.
