### PR TITLE
Event origins

### DIFF
--- a/src/baseclient.js
+++ b/src/baseclient.js
@@ -69,7 +69,7 @@
      * (start code)
      * {
      *    path: path,
-     *    origin: incoming ? 'remote' : 'window',
+     *    origin: 'window', 'local', or 'remote'
      *    oldValue: oldBody,
      *    newValue: newBody
      *  }
@@ -79,8 +79,8 @@
      *
      *
      * * the origin tells you if it's a change pulled by sync(remote)
-     * or some user action within the app(window)
-     *
+     * or some user action within the app(window) or a result of connecting
+     * with the local data store(local).
      *
      *
      * * the oldValue defaults to undefined if you are dealing with some

--- a/src/indexeddb.js
+++ b/src/indexeddb.js
@@ -31,9 +31,9 @@
    *       They have "oldValue" and "newValue" properties, which can be used to
    *       distinguish create/update/delete operations and analyze changes in
    *       change handlers. In addition they carry a "origin" property, which
-   *       is either "window" or "remote". "remote" events are fired whenever the
-   *       "incoming" flag is passed to #put() or #delete(). This is usually done
-   *       by RemoteStorage.Sync.
+   *       is either "window", "local", or "remote". "remote" events are fired
+   *       whenever the "incoming" flag is passed to #put() or #delete(). This
+   *       is usually done by RemoteStorage.Sync.
    *
    *   The revision interface (also on RemoteStorage.IndexedDB object):
    *     - #setRevision(path, revision) sets the current revision for the given
@@ -333,7 +333,7 @@
           if (path.substr(-1) !== '/') {
             this._emit('change', {
               path: path,
-              origin: 'remote',
+              origin: 'local',
               oldValue: undefined,
               newValue: cursor.value.body
             });

--- a/src/localstorage.js
+++ b/src/localstorage.js
@@ -232,7 +232,7 @@
           var node = this._get(path);
           this._emit('change', {
             path: path,
-            origin: 'remote',
+            origin: 'local',
             oldValue: undefined,
             newValue: node.body
           });

--- a/test/unit/indexeddb-suite.js
+++ b/test/unit/indexeddb-suite.js
@@ -1,0 +1,79 @@
+if(typeof(define) !== 'function') {
+  var define = require('amdefine')(module);
+}
+define(['requirejs'], function(requirejs) {
+  var suites = [];
+
+
+  suites.push({
+    name: "IndexedDB",
+    desc: "indexedDB caching layer",
+    setup: function(env, test) {
+      require('./lib/promising');
+      global.RemoteStorage = function() {};
+      require('./src/eventhandling');
+      if(global.rs_eventhandling) {
+        RemoteStorage.eventHandling = global.rs_eventhandling;
+      } else {
+        global.rs_eventhandling = RemoteStorage.eventHandling;
+      }
+      require('./src/indexeddb');
+      test.done();
+    },
+
+    beforeEach: function(env, test) {
+      var cursor = {};
+      var objectStore = function() {
+        return {
+          get: function() {
+            return {
+              onsuccess: function() {
+              }
+            };
+          },
+          openCursor: function() {
+            setTimeout(function() {
+              cursor.onsuccess({
+                target: {
+                  result: {
+                    key: 'hi',
+                    value: {
+                      body: 'basdf'
+                    }
+                  }
+                }
+              });
+            }, 0);
+            return cursor;
+          }
+        };
+      };
+      env.idb = new RemoteStorage.IndexedDB({
+        transaction: function() {
+          return {
+            objectStore: objectStore
+          };
+        }
+      });
+      test.done();
+    },
+
+    tests: [
+
+      {
+        desc: "fireInitial fires change event with 'local' origin for initial cache content",
+        timeout: 250,
+        run: function(env, test) {
+          env.idb.put('/foo/bla', 'basdf', 'text/plain');
+          env.idb.on('change', function(event) {
+            test.assert(event.origin, 'local');
+          });
+          //the mock is just an in-memory object; need to explicitly set its .length and its .key() function now:
+          env.idb.fireInitial();
+        }
+      }
+    ]
+  });
+
+  return suites;
+});

--- a/test/unit/localstorage-suite.js
+++ b/test/unit/localstorage-suite.js
@@ -224,7 +224,7 @@ define(['requirejs'], function(requirejs) {
       },
 
       {
-        desc: "#delete doesn't record a change for incoming chnages",
+        desc: "#delete doesn't record a change for incoming changes",
         run: function(env, test) {
           env.ls.put('/foo/bla', 'basfd', 'text/plain', true).then(function() {
             env.ls.delete('/foo/bla', true).then(function() {
@@ -263,6 +263,25 @@ define(['requirejs'], function(requirejs) {
             });
           });
           env.ls.put('/foo/bla', 'adsf', 'text/plain', true);
+        }
+      },
+
+      {
+        desc: "fireInitial fires change event with 'local' origin for initial cache content",
+        timeout: 250,
+        run: function(env, test) {
+          env.ls.put('/foo/bla', 'basdf', 'text/plain');
+          env.ls.on('change', function(event) {
+            test.assert(event.origin, 'local');
+          });
+          //the mock is just an in-memory object; need to explicitly set its .length and its .key() function now:
+          localStorage.length = 1;
+          localStorage.key = function(i) {
+            if(i==0) {
+              return NODES_PREFIX+'/foo/bla';
+            }
+          };
+          env.ls.fireInitial();
         }
       },
 


### PR DESCRIPTION
ok, the way it is now:

when the user first connects, the origin of events from initial sync is still `remote`. but if you then refresh the page, then the origin is now `local`. i couldn't think of a way to write tests for this, but you can try it out using the starter-kit. this resolves #457
