### PR TITLE
Fix access to conflict action when resolution attribute is set

### DIFF
--- a/src/sync.js
+++ b/src/sync.js
@@ -173,7 +173,7 @@
             if (res) {
               RemoteStorage.log('about to resolve', res);
               // ready to be resolved.
-              change.action = (res === 'remote' ? change.remoteAction : change.localAction);
+              change.action = (res === 'remote' ? change.conflict.remoteAction : change.conflict.localAction);
               change.force = true;
             } else {
               RemoteStorage.log('conflict pending for ', change.path);


### PR DESCRIPTION
The `remoteAction` and `localAction` attributes are not part of the change itself but of the conflict.

Since the `change.action` was undefined because of this, the following switch statement just kept hanging as described in #504.
