### PR TITLE
New scope name for full access

### DIFF
--- a/src/access.js
+++ b/src/access.js
@@ -13,7 +13,6 @@
   };
 
   RemoteStorage.Access.prototype = {
-    // not sure yet, if 'set' or 'claim' is better...
 
     /**
      * Method: claim
@@ -61,12 +60,23 @@
     },
 
     _adjustRootPaths: function(newScope) {
-      if('root' in this.scopeModeMap || newScope === 'root') {
+      if('*' in this.scopeModeMap || newScope === '*') {
         this.rootPaths = ['/'];
       } else if(! (newScope in this.scopeModeMap)) {
         this.rootPaths.push('/' + newScope + '/');
         this.rootPaths.push('/public/' + newScope + '/');
       }
+    },
+
+    _scopeNameForParameter: function(scope) {
+      if (scope.name === '*' && this.storageType) {
+        if (this.storageType === '2012.04') {
+          return '';
+        } else if (this.storageType.match(/remotestorage-0[01]/)) {
+          return 'root';
+        }
+      }
+      return scope.name;
     },
 
     setStorageType: function(type) {
@@ -99,7 +109,7 @@
   Object.defineProperty(RemoteStorage.Access.prototype, 'scopeParameter', {
     get: function() {
       return this.scopes.map(function(scope) {
-        return (scope.name === 'root' && this.storageType === '2012.04' ? '' : scope.name) + ':' + scope.mode;
+        return this._scopeNameForParameter(scope) + ':' + scope.mode;
       }.bind(this)).join(' ');
     }
   });
@@ -117,7 +127,7 @@
   });
 
   function setModuleCaching(remoteStorage, key) {
-    if(key === 'root' || key === '') {
+    if (key === '*' || key === '') {
       remoteStorage.caching.set('/', { data: true });
     } else {
       remoteStorage.caching.set('/' + key + '/', { data: true });

--- a/src/authorize.js
+++ b/src/authorize.js
@@ -27,18 +27,8 @@
   };
 
   RemoteStorage.prototype.authorize = function(authURL) {
-    var scopes = this.access.scopeModeMap;
-    var scope = [];
-    for(var key in scopes) {
-      var mode = scopes[key];
-      if (key === 'root') {
-        if (! this.remote.storageApi.match(/^draft-dejong-remotestorage-/)) {
-          key = '';
-        }
-      }
-      scope.push(key + ':' + mode);
-    }
-    scope = scope.join(' ');
+    this.access.setStorageType(this.remote.storageType);
+    var scope = this.access.scopeParameter;
 
     var redirectUri = String(RemoteStorage.Authorize.getLocation());
     var clientId = redirectUri.match(/^(https?:\/\/[^\/]+)/)[0];

--- a/src/wireclient.js
+++ b/src/wireclient.js
@@ -403,6 +403,15 @@
     xhr.send(body);
   };
 
+  Object.defineProperty(RemoteStorage.WireClient.prototype, 'storageType', {
+    get: function() {
+      if (this.storageApi) {
+        var spec = this.storageApi.match(/draft-dejong-(remotestorage-\d\d)/);
+        return spec ? spec[1] : '2012.04';
+      }
+    }
+  });
+
   RS.WireClient.configureHooks = [];
 
   RS.WireClient._rs_init = function(remoteStorage) {

--- a/test/unit/access-suite.js
+++ b/test/unit/access-suite.js
@@ -85,7 +85,7 @@ define(['requirejs', 'fs'], function(requirejs, fs, undefined) {
       {
         desc: "root access causes #rootPaths to only contain '/'",
         run: function(env, test) {
-          env.access.set('root', 'rw');
+          env.access.set('*', 'rw');
           test.assert(env.access.rootPaths, ['/']);
         }
       },
@@ -124,22 +124,42 @@ define(['requirejs', 'fs'], function(requirejs, fs, undefined) {
       },
 
       {
-        desc: "[2012.04] #scopeParameter is correct for the root module",
+        desc: "[2012.04] #scopeParameter is correct for root access",
         run: function(env, test) {
           env.access.reset();
           env.access.setStorageType('2012.04');
-          env.access.set('root', 'rw');
+          env.access.set('*', 'rw');
           test.assert(env.access.scopeParameter, ':rw');
         }
       },
 
       {
-        desc: "[remotestorage-00] #scopeParameter is correct for the root module",
+        desc: "[remotestorage-00] #scopeParameter is correct for root access",
         run: function(env, test) {
           env.access.reset();
           env.access.setStorageType('remotestorage-00');
-          env.access.set('root', 'rw');
+          env.access.set('*', 'rw');
           test.assert(env.access.scopeParameter, 'root:rw');
+        }
+      },
+
+      {
+        desc: "[remotestorage-01] #scopeParameter is correct for root access",
+        run: function(env, test) {
+          env.access.reset();
+          env.access.setStorageType('remotestorage-01');
+          env.access.set('*', 'rw');
+          test.assert(env.access.scopeParameter, 'root:rw');
+        }
+      },
+
+      {
+        desc: "[remotestorage-02] #scopeParameter is correct for root access",
+        run: function(env, test) {
+          env.access.reset();
+          env.access.setStorageType('remotestorage-02');
+          env.access.set('*', 'rw');
+          test.assert(env.access.scopeParameter, '*:rw');
         }
       }
 

--- a/test/unit/wireclient-suite.js
+++ b/test/unit/wireclient-suite.js
@@ -176,6 +176,28 @@ define(['requirejs'], function(requirejs, undefined) {
       },
 
       {
+        desc: "#storageType returns a simplified identifier for the current storage API",
+        run: function(env, test) {
+          env.client.storageApi = undefined;
+          test.assertTypeAnd(env.client.storageType, 'undefined');
+
+          env.client.storageApi = 'draft-dejong-remotestorage-00';
+          test.assertAnd(env.client.storageType, 'remotestorage-00');
+
+          env.client.storageApi = 'draft-dejong-remotestorage-01';
+          test.assertAnd(env.client.storageType, 'remotestorage-01');
+
+          env.client.storageApi = 'draft-dejong-remotestorage-02';
+          test.assertAnd(env.client.storageType, 'remotestorage-02');
+
+          env.client.storageApi = 'https://www.w3.org/community/rww/wiki/read-write-web-00#simple';
+          test.assertAnd(env.client.storageType, '2012.04');
+
+          test.done();
+        }
+      },
+
+      {
         desc: "#get opens a CORS request",
         run: function(env, test) {
           env.connectedClient.get('/foo/bar');


### PR DESCRIPTION
This changes the scope for requesting full storage access to '*' as discussed in remotestorage/spec/issues/48.

When an app requests full access, the appropriate scope parameter is sent to the storage provider, based on the spec version the provider supports. E.g. for storage servers supporting a spec prior to -02, the parameter is still 'root'.

This PR should only be merged for the 0.9 release, as the change of the scope is a breaking change.
