### PR TITLE
deal with folder descriptions from -02 spec in sync

### DIFF
--- a/src/sync.js
+++ b/src/sync.js
@@ -109,6 +109,15 @@
       remote.get(path, {
         ifNoneMatch: localRevision
       }).then(function(remoteStatus, remoteBody, remoteContentType, remoteRevision) {
+        //deal with folder descriptions from -02 spec:
+        var i, items={};
+        if(remoteBody && remoteBody['@context']=='http://remotestorage.io/spec/folder-description') {
+          for(i in remoteBody.items) {
+            items[i] = remoteBody.items[i].ETag;
+          }
+          remoteBody = items;
+        }
+
         if (remoteStatus === 401 || remoteStatus === 403) {
           throw new RemoteStorage.Unauthorized();
         } else if (remoteStatus === 412 || remoteStatus === 304) {


### PR DESCRIPTION
we were only dealing with them in the baseclient's getListing function so far, but the synchronize function also parses folder descriptions, so we need this conversion here as well.
