### PR TITLE
Fix typos

### DIFF
--- a/release/head/remotestorage-nocache.amd.js
+++ b/release/head/remotestorage-nocache.amd.js
@@ -211,13 +211,13 @@ define([], function() {
     /**
      * Event: conflict
      *
-     * fired when a conflict occures
+     * fired when a conflict occurs
      * TODO: arguments, how does this work
      **/
     /**
      * Event: error
      *
-     * fired when an error occures
+     * fired when an error occurs
      *
      * Arguments:
      * the error

--- a/release/head/remotestorage-nocache.js
+++ b/release/head/remotestorage-nocache.js
@@ -210,13 +210,13 @@
     /**
      * Event: conflict
      *
-     * fired when a conflict occures
+     * fired when a conflict occurs
      * TODO: arguments, how does this work
      **/
     /**
      * Event: error
      *
-     * fired when an error occures
+     * fired when an error occurs
      *
      * Arguments:
      * the error

--- a/release/head/remotestorage-node.js
+++ b/release/head/remotestorage-node.js
@@ -210,13 +210,13 @@
     /**
      * Event: conflict
      *
-     * fired when a conflict occures
+     * fired when a conflict occurs
      * TODO: arguments, how does this work
      **/
     /**
      * Event: error
      *
-     * fired when an error occures
+     * fired when an error occurs
      *
      * Arguments:
      * the error

--- a/release/head/remotestorage.amd.js
+++ b/release/head/remotestorage.amd.js
@@ -211,13 +211,13 @@ define([], function() {
     /**
      * Event: conflict
      *
-     * fired when a conflict occures
+     * fired when a conflict occurs
      * TODO: arguments, how does this work
      **/
     /**
      * Event: error
      *
-     * fired when an error occures
+     * fired when an error occurs
      *
      * Arguments:
      * the error

--- a/release/head/remotestorage.js
+++ b/release/head/remotestorage.js
@@ -210,13 +210,13 @@
     /**
      * Event: conflict
      *
-     * fired when a conflict occures
+     * fired when a conflict occurs
      * TODO: arguments, how does this work
      **/
     /**
      * Event: error
      *
-     * fired when an error occures
+     * fired when an error occurs
      *
      * Arguments:
      * the error

--- a/src/remotestorage.js
+++ b/src/remotestorage.js
@@ -95,13 +95,13 @@
     /**
      * Event: conflict
      *
-     * fired when a conflict occures
+     * fired when a conflict occurs
      * TODO: arguments, how does this work
      **/
     /**
      * Event: error
      *
-     * fired when an error occures
+     * fired when an error occurs
      *
      * Arguments:
      * the error


### PR DESCRIPTION
`s/lookpu/lookup/g`
`s/depricated/deprecated/g`
`s/occures/occurs/g`

The typos have been present since 0.8.2, but I guess we don't want to change older releases.
