### PR TITLE
Handle 404s for directory GETs (fixes #573)

### DIFF
--- a/src/wireclient.js
+++ b/src/wireclient.js
@@ -300,6 +300,10 @@
             }
             return promising().fulfill(status, listing, contentType, revision);
           }
+          // No directory listing received
+          else if (status === 404) {
+            return promising().fulfill(404);
+          }
           // Cached directory listing received
           else if (status === 304) {
             return promising().fulfill(status, body, contentType, revision);

--- a/test/unit/wireclient-suite.js
+++ b/test/unit/wireclient-suite.js
@@ -557,9 +557,26 @@ define(['requirejs'], function(requirejs, undefined) {
       },
 
       {
-        desc: "404 responses discard the body altogether",
+        desc: "404 responses for documents discard the body altogether",
         run: function(env, test) {
           env.connectedClient.get('/foo/bar').
+            then(function(status, body, contentType) {
+              test.assertAnd(status, 404);
+              test.assertTypeAnd(body, 'undefined');
+              test.assertTypeAnd(contentType, 'undefined');
+              test.done();
+            });
+          var req = XMLHttpRequest.instances.shift();
+          req.status = 404;
+          req.response = '';
+          req._onload();
+        }
+      },
+
+      {
+        desc: "404 responses for folders discard the body altogether",
+        run: function(env, test) {
+          env.connectedClient.get('/foo/bar/').
             then(function(status, body, contentType) {
               test.assertAnd(status, 404);
               test.assertTypeAnd(body, 'undefined');


### PR DESCRIPTION
This fixes directory 404s resulting in a "bad folder description" error. Please review asap.
