### PR TITLE
Fire `connected` event on startup when remote already connected

### DIFF
--- a/src/remotestorage.js
+++ b/src/remotestorage.js
@@ -436,6 +436,7 @@
           });
           if (this.remote.connected) {
             fireReady();
+            self._emit('connected');
           }
         }
 

--- a/test/unit/remotestorage-suite.js
+++ b/test/unit/remotestorage-suite.js
@@ -214,6 +214,16 @@ define([], function() {
       },
 
       {
+        desc: "fires connected when remote already connected",
+        run: function(env, test) {
+          env.rs.on('connected', function() {
+            test.done();
+          });
+          env.rs._init();
+        }
+      },
+
+      {
         desc: "connected fires ready only once",
         run: function(env, test) {
           var times = 0;


### PR DESCRIPTION
This fixes a last issue with the events: if the remote is already connected (usually when reloading the page while being connected), it should also fire the `connected` event. Forgot that in the PR yesterday and noticed it while continuing using it in an app.
