### PR TITLE
Error on remoteStorage.local.reset()

### DIFF
--- a/src/indexeddb.js
+++ b/src/indexeddb.js
@@ -152,12 +152,12 @@
       RS.IndexedDB.clean(this.db.name, function() {
         RS.IndexedDB.open(dbName, function(err, other) {
           if (err) {
-            RemoteStorage.log('[IndexedDB] Error while reseting local storage', err);
+            RemoteStorage.log('[IndexedDB] Error while resetting local storage', err);
           } else {
             // hacky!
             self.db = other;
           }
-          callback(self);
+          if (typeof callback === 'function') { callback(self); }
         });
       });
     },


### PR DESCRIPTION
I was trying to delete local storage without reloading the page (in init step of my tests), so I tried to call `remoteStorage.local.reset()`, but it throws an error :
    other is null

It seems to come from `https://github.com/remotestorage/remotestorage.js/blob/master/src/indexeddb.js#L153` : the first parameter of the callback should be the error message, not the DB.
