### PR TITLE
fix deepClone for ArrayBuffers

### DIFF
--- a/src/cachinglayer.js
+++ b/src/cachinglayer.js
@@ -20,8 +20,6 @@
     return path.substr(-1) !== '/';
   }
 
-  function isMap(x) {
-  
   /**
    * Function: fixArrayBuffers
    *


### PR DESCRIPTION
deepClone was reverting all ArrayBuffers to empty objects
