### PR TITLE
don't conflict when nothing changed, fix #642

### DIFF
--- a/src/sync.js
+++ b/src/sync.js
@@ -399,7 +399,10 @@
     },
 
     autoMergeDocument: function(node) {
-      if (node.remote.body !== undefined) {
+      if ((node.common.body === undefined && node.remote.body === false) 
+          || (node.remote.body === node.common.body && node.remote.contentType = node.common.contentType)) {
+        delete node.remote;
+      } else if (node.remote.body !== undefined) {
         // keep/revert:
         RemoteStorage.log('[Sync] Emitting keep/revert');
 


### PR DESCRIPTION
this fixes two cases:
- the document was created locally and a 404 comes in
- the document was changed locally and a 200 or 304 comes in in which nothing changed

in both these cases, the locally created version should not be deleted
