### PR TITLE
getAll now returns an empty object when there are no resources

### DIFF
--- a/src/baseclient.js
+++ b/src/baseclient.js
@@ -192,7 +192,7 @@
       }
 
       return this.storage.get(this.makePath(path), maxAge).then(function(status, body) {
-        if (status === 404) { return; }
+        if (status === 404) { return {}; }
         if (typeof(body) === 'object') {
           var promise = promising();
           var count = Object.keys(body).length, i = 0;

--- a/test/unit/baseclient-suite.js
+++ b/test/unit/baseclient-suite.js
@@ -218,13 +218,13 @@ define(['requirejs'], function(requirejs, undefined) {
       },
 
       {
-        desc: "#getAll results in 'undefined' when it sees a 404",
+        desc: "#getAll returns an empty object when it sees a 404",
         run: function(env, test) {
           env.storage.get = function(path) {
             return promising().fulfill(404);
           };
           env.client.getAll('').then(function(result) {
-            test.assertType(result, 'undefined');
+            test.assert(result, {});
           });
         }
       },


### PR DESCRIPTION
Before you had to handle `undefined` yourself.

Fixes #597
