### PR TITLE
Add unit tests for RemoteStorage.defineModule

### DIFF
--- a/test/unit/modules-suite.js
+++ b/test/unit/modules-suite.js
@@ -1,0 +1,71 @@
+if (typeof(define) !== 'function') {
+  var define = require('amdefine');
+}
+define([], function() {
+
+  var suites = [];
+
+  suites.push({
+    name: "modules",
+    desc: "RemoteStorage modules",
+    setup: function(env, test) {
+      require('./src/remotestorage');
+      if (global.rs_rs) {
+        RemoteStorage = global.rs_rs;
+      } else {
+        global.rs_rs = RemoteStorage;
+      }
+      require('./src/eventhandling');
+      if (global.rs_eventhandling) {
+        RemoteStorage.eventHandling = global.rs_eventhandling;
+      } else {
+        global.rs_eventhandling = RemoteStorage.eventHandling;
+      }
+      RemoteStorage.prototype.remote = {
+        connected: false
+      };
+      RemoteStorage.BaseClient = function() {};
+      require('./src/modules');
+      test.done();
+    },
+
+    beforeEach: function(env, test) {
+      test.done();
+    },
+
+    tests: [
+      {
+        desc: "defineModule creates a module",
+        run: function(env, test) {
+          RemoteStorage.defineModule('foo', function() {
+            return {
+              exports: {
+                it: 'worked'
+              }
+            };
+          });
+          env.rs = new RemoteStorage();
+          test.assertAnd(env.rs.foo.it, 'worked');
+          test.done();
+        }
+      },
+
+      {
+        desc: "defineModule allows hyphens",
+        run: function(env, test) {
+          RemoteStorage.defineModule('foo-bar', function() {
+            return {
+              exports: {
+                it: 'worked'
+              }
+            };
+          });
+          test.assertAnd(env.rs.fooBar.it, 'worked');
+          test.done();
+        }
+      }
+    ]
+  });
+
+  return suites;
+});

--- a/test/unit/remotestorage-suite.js
+++ b/test/unit/remotestorage-suite.js
@@ -63,9 +63,14 @@ define([], function() {
     name: "remoteStorage",
     desc: "the RemoteStorage instance",
     setup:  function(env, test) {
-      require('./src/remotestorage');
-      require('./src/eventhandling');
       require('./lib/promising');
+      require('./src/remotestorage');
+      if (global.rs_rs) {
+        RemoteStorage = global.rs_rs;
+      } else {
+        global.rs_rs = RemoteStorage;
+      }
+      require('./src/eventhandling');
       if (global.rs_eventhandling) {
         RemoteStorage.eventHandling = global.rs_eventhandling;
       } else {


### PR DESCRIPTION
This adds a couple of very basic unit tests for RemoteStorage.defineModule.

The lines added to test/unit/remotestorage-suite.js make sure that
global.RemoteStorage gets defined, even if the same file was already
included in an earlier suite (this is a general problem with using
require inside jaribu tests)

This fixes #680
