### PR TITLE
Refs #689 - Emit an event after fireInitial

### DIFF
--- a/src/cachinglayer.js
+++ b/src/cachinglayer.js
@@ -290,7 +290,9 @@
             });
           }
         }
-      }.bind(this));
+      }.bind(this)).then(function () {
+        this._emit('values-loaded');
+      });
     },
 
     onDiff: function(diffHandler) {

--- a/src/indexeddb.js
+++ b/src/indexeddb.js
@@ -55,7 +55,7 @@
     }
 
     RS.cachingLayer(this);
-    RS.eventHandling(this, 'change');
+    RS.eventHandling(this, 'change', 'values-loaded');
 
     this.getsRunning = 0;
     this.putsRunning = 0;

--- a/src/inmemorystorage.js
+++ b/src/inmemorystorage.js
@@ -9,7 +9,7 @@
   RemoteStorage.InMemoryStorage = function() {
     RemoteStorage.cachingLayer(this);
     RemoteStorage.log('[InMemoryStorage] Registering events');
-    RemoteStorage.eventHandling(this, 'change');
+    RemoteStorage.eventHandling(this, 'change', 'values-loaded');
 
     this._storage = {};
   };

--- a/src/localstorage.js
+++ b/src/localstorage.js
@@ -11,7 +11,7 @@
   RemoteStorage.LocalStorage = function() {
     RemoteStorage.cachingLayer(this);
     RemoteStorage.log('[LocalStorage] Registering events');
-    RemoteStorage.eventHandling(this, 'change');
+    RemoteStorage.eventHandling(this, 'change', 'values-loaded');
   };
 
   function b64ToUint6(nChr) {


### PR DESCRIPTION
Add a `values-loaded` event fired on local backend after all values have been loaded.

Sample usage:

```
 remoteStorage.on("features-loaded", function (e) {
   remoteStorage.local.on('values-loaded', function onValuesLoaded(ev) {
     console.log("All items loaded at " + window.performance.now());
   });
 });
```
