### PR TITLE
getAll returns empty object when directory has no objects (refs #597)

### DIFF
--- a/src/baseclient.js
+++ b/src/baseclient.js
@@ -201,7 +201,7 @@
           if (count === 0) {
             // treat this like 404. it probably means a folder listing that
             // has changes that haven't been pushed out yet.
-            return;
+            return {};
           }
           for (var key in body) {
             this.storage.get(this.makePath(path + key), maxAge).

--- a/test/unit/baseclient-suite.js
+++ b/test/unit/baseclient-suite.js
@@ -207,10 +207,33 @@ define(['requirejs'], function(requirejs, undefined) {
       },
 
       {
+        desc: "#getListing treats undefined paths as ''",
+        run: function(env, test) {
+          env.storage.get = function(path) {
+            test.assert(path, '/foo/');
+            return promising().fulfill(404);
+          };
+          env.client.getListing();
+        }
+      },
+
+      {
         desc: "#getAll returns an empty object when it sees a 404",
         run: function(env, test) {
           env.storage.get = function(path) {
             return promising().fulfill(404);
+          };
+          env.client.getAll('').then(function(result) {
+            test.assert(result, {});
+          });
+        }
+      },
+
+      {
+        desc: "#getAll returns an empty object when there are no objects",
+        run: function(env, test) {
+          env.storage.get = function(path) {
+            return promising().fulfill(200, {});
           };
           env.client.getAll('').then(function(result) {
             test.assert(result, {});
@@ -257,17 +280,6 @@ define(['requirejs'], function(requirejs, undefined) {
               baz: "content of /foo/baz"
             });
           });
-        }
-      },
-
-      {
-        desc: "#getListing treats undefined paths as ''",
-        run: function(env, test) {
-          env.storage.get = function(path) {
-            test.assert(path, '/foo/');
-            return promising().fulfill(404);
-          };
-          env.client.getListing();
         }
       },
 


### PR DESCRIPTION
There was still one case where `getAll` returns undefined instead of an empty object, that we didn't catch in #674.
