### PR TITLE
widget bubble closing spontaneously

### DIFF
--- a/src/view.js
+++ b/src/view.js
@@ -327,7 +327,6 @@
       busy: function() {
         this.div.className = "remotestorage-state-busy";
         addClass(this.cube, 'remotestorage-loading'); //TODO needs to be undone when is that neccesary
-        this.hideBubble();
       },
 
       offline: function() {


### PR DESCRIPTION
when you click the cube to disconnect, you see the bubble (balloon?) view of the widget, which has the disconnect button. But when sync requests are going on in the background, it will close again (to just the cube) before you get a chance to click it.

This can easily be reproduced by inputting a few things in the caching-strategies app on the dev branch of https://github.com/remotestorage/starter-kit.
