### PR TITLE
Use responseType ‘arraybuffer’ for all XHR requests

### DIFF
--- a/test/helpers/mocks.js
+++ b/test/helpers/mocks.js
@@ -20,6 +20,12 @@ define([], function() {
             this.result = env.fileReaderResult = Math.random();
             this._events.loadend[0]();
           }.bind(this), 0);
+        },
+        readAsText: function(buffer, encoding) {
+          setTimeout(function() {
+            this.result = env.fileReaderResult = buffer.input[0].content;
+            this._events.loadend[0]({target: {result: this.result}});
+          }.bind(this), 0);
         }
       };
       global.FakeCaching = function(){

--- a/test/unit/node-wireclient-suite.js
+++ b/test/unit/node-wireclient-suite.js
@@ -104,6 +104,33 @@ define(['requirejs'], function(requirejs) {
           req.response = 'response content';
           req._onload();
         }
+      },
+
+      {
+        desc: "GET requests for text data respond with the proper content",
+        run: function(env, test) {
+          function string2ArrayBuffer(str) {
+            var buf = new ArrayBuffer(str.length); // assuming str only contains 1-byte UTF characters
+            var bufView = new Uint8Array(buf);
+            for (var i=0, strLen=str.length; i<strLen; i++) {
+              bufView[i] = str.charCodeAt(i);
+            }
+            return buf;
+          }
+
+          env.connectedClient.get('/foo/bar').
+            then(function(status, content, contentType) {
+              test.assertAnd(status, 200);
+              test.assertAnd(content, 'response content');
+              test.assert(contentType, 'text/plain');
+            });
+
+          var req = XMLHttpRequest.instances.shift();
+          req._responseHeaders['Content-Type'] = 'text/plain';
+          req.status = 200;
+          req.response = string2ArrayBuffer('response content');
+          req._onload();
+        }
       }
     ]
   });

--- a/test/unit/wireclient-suite.js
+++ b/test/unit/wireclient-suite.js
@@ -28,11 +28,16 @@ define(['requirejs', 'test/behavior/backend', 'test/helpers/mocks'], function(re
     RemoteStorage.Authorize = {
       IMPLIED_FAKE_TOKEN: false
     };
-    
     test.done();
   }
 
   function beforeEach(env, test) {
+    global.ArrayBufferMock = function(str) {
+      return {
+        iAmA: 'ArrayBufferMock',
+        content: str
+      };
+    };
     global.XMLHttpRequest = function() {
       XMLHttpRequest.instances.push(this);
       this._headers = {};
@@ -142,7 +147,7 @@ define(['requirejs', 'test/behavior/backend', 'test/helpers/mocks'], function(re
           var req = XMLHttpRequest.instances.shift();
           req._responseHeaders['Content-Type'] = 'text/plain; charset=UTF-8';
           req.status = 200;
-          req.responseText = 'response-body';
+          req.response = new ArrayBufferMock('response-body');
           req._onload();
         }
       },
@@ -174,7 +179,7 @@ define(['requirejs', 'test/behavior/backend', 'test/helpers/mocks'], function(re
           var req = XMLHttpRequest.instances.shift();
           req._responseHeaders['Content-Type'] = 'text/plain; charset=UTF-8';
           req.status = 200;
-          req.responseText = JSON.stringify({'@context':'http://remotestorage.io/spec/folder-description', items: {}});
+          req.response = new ArrayBufferMock(JSON.stringify({'@context':'http://remotestorage.io/spec/folder-description', items: {}}));
           req._onload();
         }
       },
@@ -206,7 +211,7 @@ define(['requirejs', 'test/behavior/backend', 'test/helpers/mocks'], function(re
           var req = XMLHttpRequest.instances.shift();
           req._responseHeaders['Content-Type'] = 'text/plain; charset=UTF-8';
           req.status = 200;
-          req.responseText = 'response-body';
+          req.response = new ArrayBufferMock('response-body');
           req._onload();
         }
       },
@@ -236,7 +241,7 @@ define(['requirejs', 'test/behavior/backend', 'test/helpers/mocks'], function(re
           var req = XMLHttpRequest.instances.shift();
           req._responseHeaders['Content-Type'] = 'text/plain; charset=UTF-8';
           req.status = 200;
-          req.responseText = 'response-body';
+          req.response = new ArrayBufferMock('response-body');
           req._onload();
         }
       },
@@ -444,7 +449,7 @@ define(['requirejs', 'test/behavior/backend', 'test/helpers/mocks'], function(re
           var req = XMLHttpRequest.instances.shift();
           req._responseHeaders['Content-Type'] = 'text/plain; charset=UTF-8';
           req.status = 200;
-          req.responseText = 'response-body';
+          req.response = new ArrayBufferMock('response-body');
           req._onload();
         }
       },
@@ -461,7 +466,7 @@ define(['requirejs', 'test/behavior/backend', 'test/helpers/mocks'], function(re
           var req = XMLHttpRequest.instances.shift();
           req._responseHeaders['Content-Type'] = 'application/json; charset=UTF-8';
           req.status = 200;
-          req.responseText = '{"response":"body"}';
+          req.response = new ArrayBufferMock('{"response":"body"}');
           req._onload();
         }
       },
@@ -478,7 +483,7 @@ define(['requirejs', 'test/behavior/backend', 'test/helpers/mocks'], function(re
           var req = XMLHttpRequest.instances.shift();
           req._responseHeaders['Content-Type'] = 'application/json; charset=UTF-8';
           req.status = 200;
-          req.responseText = '{"a":"qwer","b/":"asdf"}';
+          req.response = new ArrayBufferMock('{"a":"qwer","b/":"asdf"}');
           req._onload();
         }
       },
@@ -499,7 +504,7 @@ define(['requirejs', 'test/behavior/backend', 'test/helpers/mocks'], function(re
           var req = XMLHttpRequest.instances.shift();
           req._responseHeaders['Content-Type'] = 'application/json; charset=UTF-8';
           req.status = 200;
-          req.responseText = JSON.stringify({
+          req.response = new ArrayBufferMock(JSON.stringify({
             "@context": "http://remotestorage.io/spec/folder-description",
             items: {
               a: {
@@ -513,7 +518,7 @@ define(['requirejs', 'test/behavior/backend', 'test/helpers/mocks'], function(re
                 "Content-Length": 137
               }
             }
-          });
+          }));
           req._onload();
         }
       },
@@ -649,41 +654,40 @@ define(['requirejs', 'test/behavior/backend', 'test/helpers/mocks'], function(re
       },
 
       {
-        desc: "responses with the charset set to 'binary' are read using a FileReader, after constructing a Blob",
+        desc: "responses with the charset set to 'binary' are left as the raw response",
         run: function(env, test) {
           env.connectedClient.get('/foo/bar').
             then(function(status, body, contentType) {
-              // check Blob
-              test.assertTypeAnd(env.blob, 'object');
-              test.assertAnd(env.blob.input, ['response-body']);
-              test.assertAnd(env.blob.options, {
-                type: 'application/octet-stream; charset=binary'
-              });
-
               test.assertAnd(status, 200);
-              test.assertAnd(body, env.fileReaderResult);
+              test.assertAnd(body, {
+                iAmA: 'ArrayBufferMock',
+                content: 'response-body'
+              });
               test.assert(contentType, 'application/octet-stream; charset=binary');
             });
           var req = XMLHttpRequest.instances.shift();
           req._responseHeaders['Content-Type'] = 'application/octet-stream; charset=binary';
           req.status = 200;
-          req.response = 'response-body';
+          req.response = new ArrayBufferMock('response-body');
           req._onload();
         }
       },
 
       {
-        desc: "responses without a Content-Type header still work",
+        desc: "responses without a Content-Type header are left as the raw response",
         run: function(env, test) {
           env.connectedClient.get('/foo/bar').
             then(function(status, body, contentType) {
               test.assertAnd(status, 200);
-              test.assertAnd(body, env.fileReaderResult);
+              test.assertAnd(body, {
+                iAmA: 'ArrayBufferMock',
+                content: 'response-body'
+              });
               test.done();
             });
           var req = XMLHttpRequest.instances.shift();
           req.status = 200;
-          req.response = 'response-body';
+          req.response = new ArrayBufferMock('response-body');
           req._onload();
         }
       },


### PR DESCRIPTION
Everything that is not binary is converted to string (in Node via Buffer, in Browser via Blob).

This fixes #636.

This PR replaces #715 and is ready for review.
