### PR TITLE
pass this.sync.queueGetRequest callback into this.local.get

### DIFF
--- a/src/cachinglayer.js
+++ b/src/cachinglayer.js
@@ -154,14 +154,14 @@
 
   var methods = {
 
-    get: function(path, maxAge) {
+    get: function(path, maxAge, queueGetRequest) {
       var promise = promising();
 
       if (typeof(maxAge) === 'number') {
         this.getNodes(pathsFromRoot(path)).then(function(objs) {
           var node = getLatest(objs[path]);
           if (isOutdated(objs, maxAge)) {
-            remoteStorage.sync.queueGetRequest(path, promise);
+            queueGetRequest(path, promise);
           } else if (node) {
             promise.fulfill(200, node.body || node.itemsMap, node.contentType);
           } else {

--- a/src/remotestorage.js
+++ b/src/remotestorage.js
@@ -41,7 +41,7 @@
           promise.reject('Argument \'maxAge\' must be false or a number');
           return promise;
         }
-        return this.local.get(path, maxAge);
+        return this.local.get(path, maxAge, this.sync.queueGetRequest.bind(this.sync));
       } else {
         return this.remote.get(path);
       }

--- a/test/unit/inmemorycaching-suite.js
+++ b/test/unit/inmemorycaching-suite.js
@@ -103,7 +103,7 @@ define(['requirejs'], function(requirejs) {
             }
           };
 
-          env.rs.local.get('/foo', 100).then(function(status, body, contentType) {
+          env.rs.local.get('/foo', 100, env.rs.sync.queueGetRequest.bind(env.rs.sync)).then(function(status, body, contentType) {
             test.assertAnd(requestQueued, true);
             test.assertAnd(status, 200);
             test.assertAnd(body, 'asdf');
@@ -173,7 +173,7 @@ define(['requirejs'], function(requirejs) {
             }
           };
 
-          env.rs.local.get('/foo', 100).then(function(status, body, contentType) {
+          env.rs.local.get('/foo', 100, env.rs.sync.queueGetRequest.bind(env.rs.sync)).then(function(status, body, contentType) {
             test.assertAnd(requestQueued, true);
             test.assertAnd(status, 200);
             test.assertAnd(body, 'new body');

--- a/test/unit/remotestorage-suite.js
+++ b/test/unit/remotestorage-suite.js
@@ -284,6 +284,10 @@ define([], function() {
                 test.done();
               }
             },
+            sync: {
+              queueGetRequest: function() {
+              }
+            },
             connected: false
           };
           rs.get('foo');
@@ -299,6 +303,10 @@ define([], function() {
                 test.assertAnd(path, 'foo');
                 test.assertAnd(maxAge, 34222);
                 test.done();
+              }
+            },
+            sync: {
+              queueGetRequest: function() {
               }
             },
             connected: true,

--- a/test/unit/sync-suite.js
+++ b/test/unit/sync-suite.js
@@ -555,7 +555,7 @@ define(['test/helpers/mocks'], function(mocks) {
         desc: "get with maxAge requirement is rejected if remote is not connected",
         run: function(env, test) {
           env.rs.remote.connected = false;
-          env.rs.local.get('asdf', 2).then(function() {
+          env.rs.local.get('asdf', 2, env.rs.sync.queueGetRequest.bind(env.rs.sync)).then(function() {
             test.result(false, 'should have been rejected');
           }, function(err) {
             test.done();
@@ -567,7 +567,7 @@ define(['test/helpers/mocks'], function(mocks) {
         desc: "get with maxAge requirement is rejected if remote is not online",
         run: function(env, test) {
           env.rs.remote.online = false;
-          env.rs.local.get('asdf', 2).then(function() {
+          env.rs.local.get('asdf', 2, env.rs.sync.queueGetRequest.bind(env.rs.sync)).then(function() {
             test.result(false, 'should have been rejected');
           }, function(err) {
             test.done();
@@ -583,7 +583,7 @@ define(['test/helpers/mocks'], function(mocks) {
           env.rs.remote._responses[['get', '/foo' ]] = [200, 'body', 'text/plain', 'revision'];
           env.rs.remote.connected = true;
 
-          env.rs.local.get('/foo', 5).then(function(statusCode, body, contentType) {
+          env.rs.local.get('/foo', 5, env.rs.sync.queueGetRequest.bind(env.rs.sync)).then(function(statusCode, body, contentType) {
             test.assertAnd(statusCode, 200);
             test.assertAnd(body, 'body');
             test.assertAnd(contentType, 'text/plain');
@@ -610,7 +610,7 @@ define(['test/helpers/mocks'], function(mocks) {
               }
             }
           }).then(function() {
-            env.rs.local.get('/foo', 5).then(function(statusCode, body, contentType) {
+            env.rs.local.get('/foo', 5, env.rs.sync.queueGetRequest.bind(env.rs.sync)).then(function(statusCode, body, contentType) {
               test.assertAnd(statusCode, 200);
               test.assertAnd(body, 'body');
               test.assertAnd(contentType, 'text/plain');
@@ -633,7 +633,7 @@ define(['test/helpers/mocks'], function(mocks) {
               }
             }
           }).then(function() {
-            env.rs.local.get('/foo', 120000).then(function(statusCode, body, contentType) {
+            env.rs.local.get('/foo', 120000, env.rs.sync.queueGetRequest.bind(env.rs.sync)).then(function(statusCode, body, contentType) {
               test.assertAnd(statusCode, 200);
               test.assertAnd(body, 'old data');
               test.assertAnd(contentType, 'text/html');


### PR DESCRIPTION
In the end I used a callback, so that I don't have to expose `this.local._getLatest` and `this.local.getNodes` etcetera.
