### PR TITLE
Fix Widget.display for calling it with a string of the DOM ID

### DIFF
--- a/src/widget.js
+++ b/src/widget.js
@@ -79,7 +79,7 @@
     **/
     display: function(options) {
       if (typeof(options) === 'string') {
-        options = { domID: domID };
+        options = { domID: options };
       } else if (typeof(options) === 'undefined') {
         options = {};
       }


### PR DESCRIPTION
This is the fix for #749.
