### PR TITLE
Undeprecate utils

### DIFF
--- a/src/cachinglayer.js
+++ b/src/cachinglayer.js
@@ -12,13 +12,8 @@
    * talk to.
    */
 
-  function isFolder(path) {
-    return path.substr(-1) === '/';
-  }
-
-  function isDocument(path) {
-    return path.substr(-1) !== '/';
-  }
+  var isFolder = RemoteStorage.util.isFolder;
+  var isDocument = RemoteStorage.util.isDocument;
 
   /**
    * Function: fixArrayBuffers
@@ -32,7 +27,7 @@
    */
   function fixArrayBuffers(srcObj, dstObj) {
     var field, srcArr, dstArr;
-    if (typeof(srcObj) != 'object' || Array.isArray(srcObj) || srcObj === null) {
+    if (typeof(srcObj) !== 'object' || Array.isArray(srcObj) || srcObj === null) {
       return;
     }
     for (field in srcObj) {

--- a/src/sync.js
+++ b/src/sync.js
@@ -4,6 +4,10 @@
       backgroundSyncInterval = 60000,
       isBackground = false;
 
+  var isFolder = RemoteStorage.util.isFolder;
+  var equal = RemoteStorage.util.equal;
+  var equalObj = RemoteStorage.util.equalObj;
+
   function taskFor(action, path, promise) {
     return {
       action:  action,
@@ -18,46 +22,6 @@
 
   function hasCommonRevision(node) {
     return node.common && node.common.revision;
-  }
-
-  function equal(obj1, obj2) {
-    return JSON.stringify(obj1) === JSON.stringify(obj2);
-  }
-
-  function equalObj(x, y) {
-    var p;
-    for (p in y) {
-      if (typeof(x[p]) === 'undefined') {return false;}
-    }
-    for (p in y) {
-      if (y[p]) {
-        switch (typeof(y[p])) {
-          case 'object':
-            if (!y[p].equals(x[p])) { return false; }
-            break;
-          case 'function':
-            if (typeof(x[p])==='undefined' ||
-                (p !== 'equals' && y[p].toString() !== x[p].toString())) {
-              return false;
-            }
-            break;
-          default:
-            if (y[p] !== x[p]) { return false; }
-        }
-      } else {
-        if (x[p]) { return false; }
-      }
-    }
-    for (p in x) {
-      if(typeof(y[p]) === 'undefined') {
-        return false;
-      }
-    }
-    return true;
-  }
-
-  function isFolder(path) {
-    return path.substr(-1) === '/';
   }
 
   function handleVisibility() {

--- a/src/util.js
+++ b/src/util.js
@@ -83,6 +83,43 @@
           object[key] = object[key].bind(object);
         }
       }
+    },
+
+    equal: function(obj1, obj2) {
+      return JSON.stringify(obj1) === JSON.stringify(obj2);
+    },
+
+    equalObj: function(x, y) {
+      var p;
+      for (p in y) {
+        if (typeof(x[p]) === 'undefined') {return false;}
+      }
+      for (p in y) {
+        if (y[p]) {
+          switch (typeof(y[p])) {
+            case 'object':
+              if (!y[p].equals(x[p])) { return false; }
+              break;
+            case 'function':
+              if (typeof(x[p])==='undefined' ||
+                  (p !== 'equals' && y[p].toString() !== x[p].toString())) {
+                return false;
+              }
+              break;
+            default:
+              if (y[p] !== x[p]) { return false; }
+          }
+        } else {
+          if (x[p]) { return false; }
+        }
+      }
+      for (p in x) {
+        if(typeof(y[p]) === 'undefined') {
+          return false;
+        }
+      }
+      return true;
     }
+
   };
 })();

--- a/src/wireclient.js
+++ b/src/wireclient.js
@@ -70,6 +70,8 @@
     };
   }
 
+  var isFolder = RemoteStorage.util.isFolder;
+
   function addQuotes(str) {
     if (typeof(str) !== 'string') {
       return str;
@@ -127,10 +129,6 @@
 
   function cleanPath(path) {
     return path.replace(/\/+/g, '/').split('/').map(encodeURIComponent).join('/');
-  }
-
-  function isFolder(path) {
-    return (path.substr(-1) === '/');
   }
 
   function isFolderDescription(body) {

--- a/test/unit/baseclient-suite.js
+++ b/test/unit/baseclient-suite.js
@@ -11,7 +11,7 @@ define(['requirejs', 'test/helpers/mocks'], function(requirejs, mocks) {
     desc: "High-level client, scoped to a path",
     setup: function(env, test) {
       mocks.defineMocks(env);
-  
+
       global.RemoteStorage = function() {};
       RemoteStorage.log = function() {};
       RemoteStorage.prototype = {
@@ -30,6 +30,9 @@ define(['requirejs', 'test/helpers/mocks'], function(requirejs, mocks) {
           remote: true
         }
       };
+
+      require('./src/util');
+
       require('./src/eventhandling');
       if (global.rs_eventhandling) {
         RemoteStorage.eventHandling = global.rs_eventhandling;

--- a/test/unit/baseclient/types-suite.js
+++ b/test/unit/baseclient/types-suite.js
@@ -1,7 +1,7 @@
 if (typeof(define) !== 'function') {
   var define = require('amdefine')(module);
 }
-define([], function() {
+define(['require'], function(require) {
   var suites = [];
 
   suites.push({
@@ -20,21 +20,23 @@ define([], function() {
         }
       };
 
-      require('./src/eventhandling');
+      require('./../../../src/util');
+
+      require('./../../../src/eventhandling');
       if (global.rs_eventhandling) {
         RemoteStorage.eventHandling = global.rs_eventhandling;
       } else {
         global.rs_eventhandling = RemoteStorage.eventHandling;
       }
-      require('./src/wireclient');
+      require('./../../../src/wireclient');
       if (global.rs_wireclient) {
         RemoteStorage.WireClient = global.rs_wireclient;
       } else {
         global.rs_wireclient = RemoteStorage.WireClient;
       }
 
-      require('./src/baseclient');
-      require('./src/baseclient/types');
+      require('./../../../src/baseclient.js');
+      require('./../../../src/baseclient/types');
       if (global.rs_baseclient_with_types) {
         RemoteStorage.BaseClient = global.rs_baseclient_with_types;
       } else {

--- a/test/unit/cachinglayer-suite.js
+++ b/test/unit/cachinglayer-suite.js
@@ -1,33 +1,35 @@
 if (typeof(define) !== 'function') {
   var define = require('amdefine')(module);
 }
-define(['requirejs'], function(requirejs) {
+define(['require'], function(require) {
   var suites = [];
 
   suites.push({
     name: 'CachingLayer',
     desc: 'CachingLayer that is mixed into all local storage implementations',
     setup: function(env, test) {
-      require('./lib/promising');
+      require('./../../lib/promising');
       global.RemoteStorage = function() {};
       global.RemoteStorage.log = function() {};
       global.RemoteStorage.config = {
         changeEvents: { local: true, window: false, remote: true, conflict: true }
       };
 
-      require('./src/eventhandling');
+      require('./../../src/util.js');
+
+      require('./../../src/eventhandling');
       if ( global.rs_eventhandling ) {
         RemoteStorage.eventHandling = global.rs_eventhandling;
       } else {
         global.rs_eventhandling = RemoteStorage.eventHandling;
       }
-      require('./src/cachinglayer');
+      require('./../../src/cachinglayer.js');
       if (global.rs_cachinglayer) {
         RemoteStorage.cachingLayer = global.rs_cachinglayer;
       } else {
         global.rs_cachinglayer = RemoteStorage.cachingLayer;
       }
-      require('./src/inmemorystorage');
+      require('./../../src/inmemorystorage');
       if (global.rs_ims) {
         RemoteStorage.InMemoryStorage = global.rs_ims;
       } else {

--- a/test/unit/indexeddb-suite.js
+++ b/test/unit/indexeddb-suite.js
@@ -1,32 +1,32 @@
 if (typeof(define) !== 'function') {
   var define = require('amdefine')(module);
 }
-define(['requirejs'], function(requirejs) {
+define(['require'], function(require) {
   var suites = [];
 
   suites.push({
     name: "IndexedDB",
     desc: "indexedDB caching layer",
     setup: function(env, test) {
-      require('./lib/promising');
+      require('./../../lib/promising.js');
       global.RemoteStorage = function() {};
       global.RemoteStorage.log = function() {};
       global.RemoteStorage.config = {
         changeEvents: { local: true, window: false, remote: true, conflict: true }
       };
-      require('./src/eventhandling');
+      require('./../../src/eventhandling.js');
       if (global.rs_eventhandling) {
         RemoteStorage.eventHandling = global.rs_eventhandling;
       } else {
         global.rs_eventhandling = RemoteStorage.eventHandling;
       }
-      require('./src/cachinglayer');
+      require('./../../src/cachinglayer.js');
       if (global.rs_cachinglayer) {
         RemoteStorage.cachingLayer = global.rs_cachinglayer;
       } else {
         global.rs_cachinglayer = RemoteStorage.cachingLayer;
       }
-      require('./src/indexeddb');
+      require('./../../src/indexeddb.js');
       test.done();
     },
 

--- a/test/unit/inmemorycaching-suite.js
+++ b/test/unit/inmemorycaching-suite.js
@@ -1,7 +1,7 @@
 if (typeof(define) !== 'function') {
   var define = require('amdefine')(module);
 }
-define(['requirejs'], function(requirejs) {
+define(['require'], function(require) {
   var suites = [];
 
   suites.push({
@@ -9,25 +9,25 @@ define(['requirejs'], function(requirejs) {
     desc: 'In-memory caching layer',
 
     setup: function(env, test) {
-      require('./lib/promising');
+      require('./../../lib/promising.js');
       global.RemoteStorage = function() {};
       global.RemoteStorage.log = function() {};
       global.RemoteStorage.config = {
         changeEvents: { local: true, window: false, remote: true, conflict: true }
       };
-      require('./src/eventhandling');
+      require('./../../src/eventhandling.js');
       if ( global.rs_eventhandling ) {
         RemoteStorage.eventHandling = global.rs_eventhandling;
       } else {
         global.rs_eventhandling = RemoteStorage.eventHandling;
       }
-      require('./src/cachinglayer');
+      require('./../../src/cachinglayer.js');
       if (global.rs_cachinglayer) {
         RemoteStorage.cachingLayer = global.rs_cachinglayer;
       } else {
         global.rs_cachinglayer = RemoteStorage.cachingLayer;
       }
-      require('./src/inmemorystorage');
+      require('./../../src/inmemorystorage.js');
       if (global.rs_ims) {
         RemoteStorage.InMemoryStorage = global.rs_ims;
       } else {

--- a/test/unit/localstorage-suite.js
+++ b/test/unit/localstorage-suite.js
@@ -1,7 +1,7 @@
 if (typeof(define) !== 'function') {
   var define = require('amdefine')(module);
 }
-define(['requirejs'], function(requirejs) {
+define(['require'], function(require) {
   var suites = [];
 
   var NODES_PREFIX = 'remotestorage:cache:nodes:';
@@ -45,25 +45,25 @@ define(['requirejs'], function(requirejs) {
     desc: "localStorage caching layer",
 
     setup: function(env, test) {
-      require('./lib/promising');
+      require('./../../lib/promising.js');
       global.RemoteStorage = function() {};
       global.RemoteStorage.log = function() {};
       global.RemoteStorage.config = {
         changeEvents: { local: true, window: false, remote: true, conflict: true }
       };
-      require('./src/eventhandling');
+      require('./../../src/eventhandling.js');
       if (global.rs_eventhandling) {
         RemoteStorage.eventHandling = global.rs_eventhandling;
       } else {
         global.rs_eventhandling = RemoteStorage.eventHandling;
       }
-      require('./src/cachinglayer');
+      require('./../../src/cachinglayer.js');
       if (global.rs_cachinglayer) {
         RemoteStorage.cachingLayer = global.rs_cachinglayer;
       } else {
         global.rs_cachinglayer = RemoteStorage.cachingLayer;
       }
-      require('./src/localstorage');
+      require('./../../src/localstorage.js');
       test.done();
     },
 

--- a/test/unit/node-wireclient-suite.js
+++ b/test/unit/node-wireclient-suite.js
@@ -13,6 +13,7 @@ define(['requirejs'], function(requirejs) {
       RemoteStorage.log = function() {};
       global.RemoteStorage.Unauthorized = function() {};
       require('./lib/promising');
+      require('./src/util');
       require('./src/eventhandling');
 
       if (global.rs_eventhandling) {
@@ -20,7 +21,7 @@ define(['requirejs'], function(requirejs) {
       } else {
         global.rs_eventhandling = RemoteStorage.eventHandling;
       }
-      require('./src/wireclient');
+      requirejs('./src/wireclient');
       if (global.rs_wireclient) {
         RemoteStorage.WireClient = global.rs_wireclient;
       } else {
@@ -37,7 +38,9 @@ define(['requirejs'], function(requirejs) {
     },
 
     takedown: function(env, test) {
-      RemoteStorage.WireClient.readBinaryData = oldReadBinaryData;
+      if (typeof RemoteStorage.WireClient !== 'undefined') {
+         RemoteStorage.WireClient.readBinaryData = oldReadBinaryData;
+      }
       test.done();
     },
 

--- a/test/unit/remotestorage-suite.js
+++ b/test/unit/remotestorage-suite.js
@@ -1,7 +1,7 @@
 if (typeof(define) !== 'function') {
-  var define = require('amdefine');
+  var define = require('amdefine.js');
 }
-define([], function() {
+define([requirejs], function(requirejs) {
 
   var suites = [];
 
@@ -70,7 +70,7 @@ define([], function() {
       } else {
         global.rs_rs = RemoteStorage;
       }
-      require('./src/eventhandling');
+      require('./src/eventhandling.js');
       if (global.rs_eventhandling) {
         RemoteStorage.eventHandling = global.rs_eventhandling;
       } else {
@@ -325,7 +325,7 @@ define([], function() {
     name: "RemoteStorage",
     desc: "The global RemoteStorage namespace",
     setup: function(env, test) {
-      require('./src/remotestorage');
+      require('./src/remotestorage.js');
       test.done();
     },
 

--- a/test/unit/sync-suite.js
+++ b/test/unit/sync-suite.js
@@ -2,7 +2,7 @@ if (typeof(define) !== 'function') {
   var define = require('amdefine');
 }
 
-define(['test/helpers/mocks'], function(mocks) {
+define(['test/helpers/mocks', 'requirejs'], function(mocks, requirejs) {
   var suites = [];
 
   function flatten(array){
@@ -21,7 +21,7 @@ define(['test/helpers/mocks'], function(mocks) {
     setup: function(env, test){
       mocks.defineMocks(env);
 
-      require('./lib/promising');
+      require('./lib/promising.js');
       global.RemoteStorage = function(){
         RemoteStorage.eventHandling(this, 'sync-busy', 'sync-done', 'ready', 'sync-interval-change', 'error');
       };
@@ -32,14 +32,16 @@ define(['test/helpers/mocks'], function(mocks) {
       RemoteStorage.Unauthorized = function() { Error.apply(this, arguments); };
       RemoteStorage.Unauthorized.prototype = Object.create(Error.prototype);
 
-      require('./src/eventhandling');
+      require('./src/util.js');
+
+      require('./src/eventhandling.js');
       if (global.rs_eventhandling){
         RemoteStorage.eventHandling = global.rs_eventhandling;
       } else {
         global.rs_eventhandling = RemoteStorage.eventHandling;
       }
 
-      require('./src/cachinglayer');
+      require('./src/cachinglayer.js');
       if (global.rs_cachinglayer) {
         RemoteStorage.cachingLayer = global.rs_cachinglayer;
       } else {
@@ -53,14 +55,14 @@ define(['test/helpers/mocks'], function(mocks) {
         global.rs_ims = RemoteStorage.InMemoryStorage;
       }
 
-      require('src/sync.js');
+      require('./src/sync.js');
       if (global.rs_sync) {
         RemoteStorage.Sync = global.rs_sync;
       } else {
         global.rs_sync = RemoteStorage.Sync;
       }
 
-      require('src/authorize.js');
+      require('./src/authorize.js');
       if (global.rs_authorize) {
         RemoteStorage.Authorize = global.rs_authorize;
       } else {
@@ -1150,7 +1152,7 @@ define(['test/helpers/mocks'], function(mocks) {
             }, 0);
           };
           env.rs.sync.now = function() { return 1234567890123; };
-          env.rs.sync.completePush('foo', 'put', true, '123')
+          env.rs.sync.completePush('foo', 'put', true, '123');
         }
       }
     ]

--- a/test/unit/versioning-suite.js
+++ b/test/unit/versioning-suite.js
@@ -2,7 +2,7 @@ if (typeof(define) !== 'function') {
   var define = require('amdefine');
 }
 
-define([], function() {
+define(['requirejs'], function(requirejs) {
   var suites = [];
 
   function FakeCaching(){
@@ -89,7 +89,7 @@ define([], function() {
         global.rs_eventhandling = RemoteStorage.eventHandling;
       }
 
-      require('./src/cachinglayer');
+      require('./src/cachinglayer.js');
       if (global.rs_cachinglayer) {
         RemoteStorage.cachingLayer = global.rs_cachinglayer;
       } else {

--- a/test/unit/wireclient-suite.js
+++ b/test/unit/wireclient-suite.js
@@ -11,6 +11,7 @@ define(['requirejs', 'test/behavior/backend', 'test/helpers/mocks'], function(re
     global.RemoteStorage.SyncError = function() {};
     global.RemoteStorage.prototype.localStorageAvailable = function() { return false; };
     require('./lib/promising');
+    require('./src/util');
     require('./src/eventhandling');
 
     if (global.rs_eventhandling) {


### PR DESCRIPTION
(This is the fixed version of #760)

This reverses the deprecation of the util function module, because we agreed that we should have a central place for them again. Also, we're planning to add the module helpers (like e.g. CredentialsStore) to that same namespace, so they don't pollute the global context.
