### PR TITLE
promise failures should ensure there's a stack trace, and create one if not

### DIFF
--- a/lib/promising.js
+++ b/lib/promising.js
@@ -59,12 +59,19 @@
       }
       success = succ;
       result = Array.prototype.slice.call(res);
-      setTimeout(function() {
+      var stack;
+      if (result.hasOwnProperty('stack')) {
+        stack = result.stack;
+      } else {
+        stack = new Error('').stack;
+      }
+      setTimeout(function () {
         var cl = consumers.length;
-        if(cl === 0 && (! success)) {
-          console.error("Possibly uncaught error: ", result, result[0] && result[0].stack);
+        if ((cl === 0) && (! success)) {
+          console.error("Possibly uncaught error: ", result, stack);
         }
-        for(var i=0;i<cl;i++) {
+
+        for(var i = 0; i < cl; i++) {
           notifyConsumer(consumers[i]);
         }
         consumers = undefined;
@@ -93,12 +100,12 @@
         resolve(true, arguments);
         return this;
       },
-      
+
       reject: function() {
         resolve(false, arguments);
         return this;
       }
-      
+
     };
 
     return promise;


### PR DESCRIPTION
When a promise is uncaught (or promising thinks it's uncaught) it throws an error, but this usually does not have a stack trace. This makes tracking down your potential problem-areas difficult. 

This patch will create a stack track if one does not exist, during async errors this isn't too helpful (but not any less helpful) because the stack trace just tracks down to the timer. However for non-async errors this is much more helpful, giving you a stack of places in the code touched.
