### PR TITLE
Clean up Dropbox documentation

### DIFF
--- a/doc/config/Menu.txt
+++ b/doc/config/Menu.txt
@@ -90,5 +90,6 @@ Group: Index  {
    Function Index: Functions
    Property Index: Properties
    Interface Index: Interfaces
+   File Index: Files
    }  # Group: Index
 

--- a/src/dropbox.js
+++ b/src/dropbox.js
@@ -2,7 +2,7 @@
   var RS = RemoteStorage;
 
   /**
-   * Class: RemoteStorage.Dropbox
+   * File: Dropbox
    *
    * WORK IN PROGRESS, NOT RECOMMENDED FOR PRODUCTION USE
    *


### PR DESCRIPTION
It's quite a mess: http://remotestorage.io/doc/code/files/dropbox-js.html

Also, it doesn't explain how to enable Dropbox for experimenting and developing.
