### PR TITLE
Refactor discovery code to use promises

### DIFF
--- a/src/authorize.js
+++ b/src/authorize.js
@@ -19,7 +19,9 @@
   RemoteStorage.ImpliedAuth = function (storageApi, redirectUri) {
     RemoteStorage.log('ImpliedAuth proceeding due to absent authURL; storageApi = ' + storageApi + ' redirectUri = ' + redirectUri);
     // Set a fixed access token, signalling to not send it as Bearer
-    remoteStorage.remote.configure(undefined, undefined, undefined, RemoteStorage.Authorize.IMPLIED_FAKE_TOKEN);
+    remoteStorage.remote.configure({
+      token: RemoteStorage.Authorize.IMPLIED_FAKE_TOKEN
+    });
     document.location = redirectUri;
   };
 
@@ -92,7 +94,9 @@
           throw "Authorization server errored: " + params.error;
         }
         if (params.access_token) {
-          remoteStorage.remote.configure(undefined, undefined, undefined, params.access_token);
+          remoteStorage.remote.configure({
+            token: params.access_token
+          });
           authParamsUsed = true;
         }
         if (params.remotestorage) {

--- a/src/discover.js
+++ b/src/discover.js
@@ -10,23 +10,27 @@
   /**
    * Class: RemoteStorage.Discover
    *
-   * This class deals with the Webfinger lookup, discovering a connecting
+   * This function deals with the Webfinger lookup, discovering a connecting
    * user's storage details.
    *
    * The discovery timeout can be configured via
    * `RemoteStorage.config.discoveryTimeout` (in ms).
    *
    * Arguments:
+   *
    *   userAddress - user@host
-   *   callback    - gets called with href of the storage, the type and the authURL
+   *
+   * Returns:
+   *
+   * A promise for an object with the following properties.
+   *
+   *   href - Storage base URL,
+   *   storageType - Storage type,
+   *   authUrl - OAuth URL
    **/
 
-  RemoteStorage.Discover = function (userAddress, callback) {
-    if (userAddress in cachedInfo) {
-      var info = cachedInfo[userAddress];
-      callback(info.href, info.type, info.authURL);
-      return;
-    }
+  RemoteStorage.Discover = function (userAddress) {
+    var pending = Promise.defer();
     var hostname = userAddress.split('@')[1];
     var params = '?resource=' + encodeURIComponent('acct:' + userAddress);
     var urls = [
@@ -34,10 +38,19 @@
       'http://' + hostname + '/.well-known/webfinger' + params
     ];
 
+    if (userAddress in cachedInfo) {
+      var info = cachedInfo[userAddress];
+      pending.resolve(info);
+      return pending.promise;
+    }
+
     function tryOne() {
       var xhr = new XMLHttpRequest();
       var url = urls.shift();
-      if (!url) { return callback(); }
+      if (!url) {
+        pending.reject('Discovery failed for all URLs');
+        return;
+      }
       RemoteStorage.log('[Discover] Trying URL', url);
       xhr.open('GET', url, true);
       xhr.onabort = xhr.onerror = function () {
@@ -76,11 +89,15 @@
                   || link.properties['auth-endpoint'],
             storageType = link.properties['http://remotestorage.io/spec/version']
                   || link.type;
-          cachedInfo[userAddress] = { href: link.href, type: storageType, authURL: authURL };
+          cachedInfo[userAddress] = { href: link.href, storageType: storageType, authURL: authURL };
           if (hasLocalStorage) {
             localStorage[SETTINGS_KEY] = JSON.stringify({ cache: cachedInfo });
           }
-          callback(link.href, storageType, authURL);
+          pending.resolve({
+            href: link.href,
+            storageType: storageType,
+            authURL: authURL
+          });
         } else {
           tryOne();
         }
@@ -88,6 +105,7 @@
       xhr.send();
     }
     tryOne();
+    return pending.promise;
   };
 
   RemoteStorage.Discover._rs_init = function (remoteStorage) {

--- a/src/dropbox.js
+++ b/src/dropbox.js
@@ -159,7 +159,14 @@
 
     onErrorCb = function (error){
       if (error instanceof RemoteStorage.Unauthorized) {
-        self.configure(null,null,null,null);
+        // Delete all the settings - see the documentation of wireclient.configure
+        self.configure({
+          userAddress: null,
+          href: null,
+          storageApi: null,
+          token: null,
+          options: null
+        });
       }
     };
 
@@ -177,7 +184,7 @@
         settings = JSON.parse(localStorage[SETTINGS_KEY]);
       } catch(e){}
       if (settings) {
-        this.configure(settings.userAddress, undefined, undefined, settings.token);
+        this.configure(settings);
       }
       try {
         this._itemRefs = JSON.parse(localStorage[ SETTINGS_KEY+':shares' ]);
@@ -208,14 +215,15 @@
     },
 
     /**
-     * Method: configure
-     *
+     * Method : configure(settings)
      * Accepts its parameters according to the <RemoteStorage.WireClient>.
-     * Set's the connected flag.
-     */
-    configure: function (userAddress, href, storageApi, token) {
-      if (typeof token !== 'undefined') { this.token = token; }
-      if (typeof userAddress !== 'undefined') { this.userAddress = userAddress; }
+     * Sets the connected flag
+     **/
+    configure: function (settings) {
+      // We only update this.userAddress if settings.userAddress is set to a string or to null:
+      if (typeof settings.userAddress !== 'undefined') { this.userAddress = settings.userAddress; }
+      // Same for this.token. If only one of these two is set, we leave the other one at its existing value:
+      if (typeof settings.token !== 'undefined') { this.token = settings.token; }
 
       if (this.token) {
         this.connected = true;
@@ -230,8 +238,10 @@
         this.connected = false;
       }
       if (hasLocalStorage){
-        localStorage[SETTINGS_KEY] = JSON.stringify( { token: this.token,
-                                                       userAddress: this.userAddress } );
+        localStorage[SETTINGS_KEY] = JSON.stringify({
+          userAddress: this.userAddress,
+          token: this.token
+        });
       }
     },
 

--- a/src/googledrive.js
+++ b/src/googledrive.js
@@ -78,10 +78,10 @@
     connected: false,
     online: true,
 
-    configure: function (_x, _y, _z, token) { // parameter list compatible with WireClient
-      if (token) {
-        localStorage['remotestorage:googledrive:token'] = token;
-        this.token = token;
+    configure: function (settings) { // Settings parameter compatible with WireClient
+      if (settings.token) {
+        localStorage['remotestorage:googledrive:token'] = settings.token;
+        this.token = settings.token;
         this.connected = true;
         this._emit('connected');
       } else {

--- a/test/unit/authorize-suite.js
+++ b/test/unit/authorize-suite.js
@@ -117,8 +117,8 @@ define(['requirejs', 'fs'], function(requirejs, fs, undefined) {
           document.location.href = 'http://foo/bar#access_token=my-token';
           RemoteStorage.Authorize._rs_init(storage);
           storage.remote = {
-            configure: function(userAddress, href, type, token) {
-              test.assert(token, 'my-token');
+            configure: function(settings) {
+              test.assert(settings.token, 'my-token');
             }
           };
           storage._handlers['features-loaded'][0]();
@@ -132,7 +132,7 @@ define(['requirejs', 'fs'], function(requirejs, fs, undefined) {
           document.location.href = 'http://foo/bar#access_token=my-token&state=custom%2Fpath';
           RemoteStorage.Authorize._rs_init(storage);
           storage.remote = {
-            configure: function(userAddress, href, type, token) {}
+            configure: function(settings) {}
           };
           storage._handlers['features-loaded'][0]();
 

--- a/test/unit/discover-suite.js
+++ b/test/unit/discover-suite.js
@@ -1,7 +1,8 @@
 if (typeof define !== 'function') {
   var define = require('amdefine')(module);
 }
-define(['requirejs', 'fs'], function(requirejs, fs, undefined) {
+define(['bluebird', 'requirejs', 'fs'], function(Promise, requirejs, fs) {
+  global.Promise = Promise;
   var suites = [];
 
   suites.push({
@@ -53,7 +54,7 @@ define(['requirejs', 'fs'], function(requirejs, fs, undefined) {
 
       {
         desc: "it isn't supported with no XMLHttpRequest",
-        run: function(env, test) {
+        run: function (env, test) {
           delete global.XMLHttpRequest; // in case it was declared by another test.
           test.assert(RemoteStorage.Discover._rs_supported(), false);
         }
@@ -61,7 +62,7 @@ define(['requirejs', 'fs'], function(requirejs, fs, undefined) {
 
       {
         desc: "it is supported when XMLHttpRequest is defined",
-        run: function(env, test) {
+        run: function (env, test) {
           global.XMLHttpRequest = function() {
             XMLHttpRequest.instances.push(this);
           };
@@ -71,7 +72,7 @@ define(['requirejs', 'fs'], function(requirejs, fs, undefined) {
 
       {
         desc: "initialization works",
-        run: function(env, test) {
+        run: function (env, test) {
           var rs = new RemoteStorage();
           RemoteStorage.Discover._rs_init(rs);
           test.done();
@@ -80,8 +81,8 @@ define(['requirejs', 'fs'], function(requirejs, fs, undefined) {
 
       {
         desc: "it tries /.well-known/webfinger",
-        run: function(env, test) {
-          RemoteStorage.Discover('nil@heahdk.net', function() {} );
+        run: function (env, test) {
+          RemoteStorage.Discover('nil@heahdk.net');
           test.assertAnd(XMLHttpRequest.openCalls.length, 1);
           test.assertAnd(XMLHttpRequest.openCalls[0][0], 'GET');
           test.assertAnd(XMLHttpRequest.openCalls[0][1], 'https://heahdk.net/.well-known/webfinger?resource=acct%3Anil%40heahdk.net');
@@ -92,11 +93,13 @@ define(['requirejs', 'fs'], function(requirejs, fs, undefined) {
 
       {
         desc: "it finds href, type and authURL, when the remotestorage version is in the link type",
-        run: function(env, test) {
-          RemoteStorage.Discover('nil@heahdk.net', function(href, type, authURL) {
-            test.assertAnd(href, 'https://base/url');
-            test.assertAnd(type, 'draft-dejong-remotestorage-01');
-            test.assertAnd(authURL, 'https://auth/url');
+        run: function (env, test) {
+          RemoteStorage.Discover('nil@heahdk.net').then(function(info) {
+            test.assertAnd(info, {
+              href: 'https://base/url',
+              storageType: 'draft-dejong-remotestorage-01',
+              authURL: 'https://auth/url'
+            });
             test.done();
           });
           var instance = XMLHttpRequest.instances[0];
@@ -118,15 +121,17 @@ define(['requirejs', 'fs'], function(requirejs, fs, undefined) {
       },
 
       {
-        desc: "it finds href, type and authURL, when the remotestorage version is in a link property",
-        run: function(env, test) {
+        desc: "it finds href, type, and authURL when the remotestorage version is in a link property",
+        run: function (env, test) {
           //TODO: clear the cache of the discover instance inbetween tests.
           //for now, we use a different user address in each test to avoid interference
           //between the previous test and this one when running the entire suite.
-          RemoteStorage.Discover('nil2@heahdk.net', function(href, type, authURL) {
-            test.assertAnd(href, 'https://base/url');
-            test.assertAnd(type, 'draft-dejong-remotestorage-02');
-            test.assertAnd(authURL, 'https://auth/url');
+          RemoteStorage.Discover('nil2@heahdk.net').then(function (info) {
+            test.assertAnd(info, {
+              href: 'https://base/url',
+              storageType: 'draft-dejong-remotestorage-02',
+              authURL: 'https://auth/url'
+            });
             test.done();
           });
           var instance = XMLHttpRequest.instances[0];
@@ -148,10 +153,28 @@ define(['requirejs', 'fs'], function(requirejs, fs, undefined) {
       },
 
       {
-        desc: "if unseccesfully tried to discover a storage, callback is called without an href",
-        run: function(env, test) {
-          RemoteStorage.Discover("foo@bar", function(href) {
-            test.assertType(href, 'undefined');
+        desc: "when running the previous test a second time, it makes no xhr request, but you get the same answer",
+        run: function (env, test) {
+          //TODO: clear the cache of the discover instance inbetween tests.
+          //for now, we use a different user address in each test to avoid interference
+          //between the previous test and this one when running the entire suite.
+          RemoteStorage.Discover('nil2@heahdk.net').then(function (info) {
+            test.assertAnd(info, {
+              href: 'https://base/url',
+              storageType: 'draft-dejong-remotestorage-02',
+              authURL: 'https://auth/url'
+            });
+            test.done();
+          });
+          test.assertAnd(XMLHttpRequest.instances[0], undefined);
+        }
+      },
+
+      {
+        desc: "if unsuccesfully tried to discover a storage, promise is rejected",
+        run: function (env, test) {
+          RemoteStorage.Discover("foo@bar").then(undefined, function(err) {
+            test.assertType(err, 'string');
           });
           for (var i = 0; i < 4; i++) {
             var instance = XMLHttpRequest.instances[i];

--- a/test/unit/dropbox-suite.js
+++ b/test/unit/dropbox-suite.js
@@ -88,9 +88,11 @@ define(['bluebird', 'requirejs', 'test/behavior/backend', 'test/helpers/mocks'],
     env.connectedClient = new RemoteStorage.Dropbox(env.rs);
     env.baseURI = 'https://example.com/storage/test';
     env.token = 'foobarbaz';
-    env.connectedClient.configure(
-      'dboxuser', env.baseURI, undefined, env.token
-    );
+    env.connectedClient.configure({
+      userAddress: 'dboxuser',
+      href: env.baseURI,
+      token: env.token
+    });
 
     mocks.defineMocks(env);
 
@@ -149,20 +151,25 @@ define(['bluebird', 'requirejs', 'test/behavior/backend', 'test/helpers/mocks'],
       {
         desc: "#configure sets the userAddress",
         run: function (env, test) {
-          env.client.configure('test@example.com');
-          test.assert(env.client.userAddress, 'test@example.com');
+          env.client.configure({ userAddress: 'test@example.com' });
+          test.assertAnd(env.client.userAddress, 'test@example.com');
+
+          test.done();
         }
       },
 
       {
         desc: "#configure doesn't overwrite parameters if they are given as 'undefined'",
         run: function (env, test) {
-          env.client.configure('test@example.com');
+          env.client.configure({ userAddress: 'test@example.com' });
           test.assertAnd(env.client.userAddress, 'test@example.com');
-          env.client.configure(undefined, undefined, undefined, 'abcd');
+          env.client.configure({ token: 'abcd' });
           test.assertAnd(env.client.userAddress, 'test@example.com');
           test.assertAnd(env.client.token, 'abcd');
-          env.client.configure(null, undefined, undefined, null);
+          env.client.configure({
+            userAddress: null,
+            token: null
+          });
           test.assertAnd(env.client.token, null);
           test.assertAnd(env.client.userAddress, null);
           test.done();
@@ -172,7 +179,7 @@ define(['bluebird', 'requirejs', 'test/behavior/backend', 'test/helpers/mocks'],
       {
         desc: "#configure sets 'connected' to true, once token is given",
         run: function (env, test) {
-          env.client.configure(undefined, undefined, undefined, 'foobarbaz');
+          env.client.configure({ token: 'foobarbaz' });
           test.assert(env.client.connected, true);
         }
       },

--- a/test/unit/googledrive-suite.js
+++ b/test/unit/googledrive-suite.js
@@ -86,9 +86,11 @@ define(['bluebird', 'requirejs', 'test/behavior/backend', 'test/helpers/mocks'],
     env.connectedClient = new RemoteStorage.GoogleDrive(env.rs);
     env.baseURI = 'https://example.com/storage/test';
     env.token = 'foobarbaz';
-    env.connectedClient.configure(
-      'gduser', env.baseURI, undefined, env.token
-    );
+    env.connectedClient.configure({
+      userAddress: 'gduser',
+      href: env.baseURI,
+      token: env.token
+    });
 
     mocks.defineMocks(env);
 
@@ -124,7 +126,9 @@ define(['bluebird', 'requirejs', 'test/behavior/backend', 'test/helpers/mocks'],
       {
         desc: "#configure sets 'connected' to true, once token is given",
         run: function (env, test) {
-          env.client.configure(undefined, undefined, undefined, 'foobarbaz');
+          env.client.configure({
+            token: 'foobarbaz'
+          });
           test.assert(env.client.connected, true);
         }
       },

--- a/test/unit/node-wireclient-suite.js
+++ b/test/unit/node-wireclient-suite.js
@@ -58,9 +58,10 @@ define(['require'], function (require) {
       env.connectedClient = new RemoteStorage.WireClient(env.rs);
       env.baseURI = 'https://example.com/storage/test';
       env.token = 'foobarbaz';
-      env.connectedClient.configure(
-        undefined, env.baseURI, undefined, env.token
-      );
+      env.connectedClient.configure({
+        href: env.baseURI,
+        token: env.token
+      });
       test.done();
     },
 

--- a/test/unit/remotestorage-suite.js
+++ b/test/unit/remotestorage-suite.js
@@ -80,10 +80,12 @@ define(['bluebird', 'requirejs'], function (Promise, requirejs) {
       } else {
         global.rs_eventhandling = RemoteStorage.eventHandling;
       }
-      RemoteStorage.Discover = function(userAddress, callback) {
+      RemoteStorage.Discover = function(userAddress) {
+        var pending = Promise.defer();
         if (userAddress === "someone@somewhere") {
-          callback();
+          pending.reject('in this test, discovery fails for that address');
         }
+        return  pending.promise;
       };
       global.localStorage = {};
       RemoteStorage.prototype.remote = new FakeRemote();

--- a/test/unit/wireclient-suite.js
+++ b/test/unit/wireclient-suite.js
@@ -80,9 +80,10 @@ define(['bluebird', 'requirejs', 'test/behavior/backend', 'test/helpers/mocks'],
     env.connectedClient = new RemoteStorage.WireClient(env.rs);
     env.baseURI = 'https://example.com/storage/test';
     env.token = 'foobarbaz';
-    env.connectedClient.configure(
-      undefined, env.baseURI, undefined, env.token
-    );
+    env.connectedClient.configure({
+      href: env.baseURI,
+      token: env.token
+    });
 
     mocks.defineMocks(env);
 
@@ -274,7 +275,10 @@ define(['bluebird', 'requirejs', 'test/behavior/backend', 'test/helpers/mocks'],
       {
         desc: "#configure sets the given parameters",
         run: function(env, test) {
-          env.client.configure('test@example.com', undefined, 'draft-dejong-remotestorage-00');
+          env.client.configure({
+            userAddress: 'test@example.com',
+            storageApi: 'draft-dejong-remotestorage-00'
+          });
           test.assertAnd(env.client.userAddress, 'test@example.com');
           test.assertAnd(env.client.storageApi, 'draft-dejong-remotestorage-00');
           test.done();
@@ -284,9 +288,11 @@ define(['bluebird', 'requirejs', 'test/behavior/backend', 'test/helpers/mocks'],
       {
         desc: "#configure doesn't overwrite parameters if they are given as 'undefined'",
         run: function(env, test) {
-          env.client.configure('test@example.com');
+          env.client.configure({
+            userAddress: 'test@example.com'
+          });
           test.assertAnd(env.client.userAddress, 'test@example.com');
-          env.client.configure(undefined, 'http://foo/bar');
+          env.client.configure({ href: 'http://foo/bar' });
           test.assertAnd(env.client.userAddress, 'test@example.com');
           test.assertAnd(env.client.href, 'http://foo/bar');
           test.done();
@@ -296,11 +302,17 @@ define(['bluebird', 'requirejs', 'test/behavior/backend', 'test/helpers/mocks'],
       {
         desc: "#configure determines if revisions are supported, based on the storageApi",
         run: function(env, test) {
-          env.client.configure(undefined, undefined, 'draft-dejong-remotestorage-00');
+          env.client.configure({
+            storageApi: 'draft-dejong-remotestorage-00'
+          });
           test.assertAnd(env.client.supportsRevs, true);
-          env.client.configure(undefined, undefined, 'https://www.w3.org/community/rww/wiki/read-write-web-00#simple');
+          env.client.configure({
+            storageApi: 'https://www.w3.org/community/rww/wiki/read-write-web-00#simple'
+          });
           test.assertAnd(env.client.supportsRevs, false);
-          env.client.configure(undefined, undefined, 'draft-dejong-remotestorage-01');
+          env.client.configure({
+            storageApi: 'draft-dejong-remotestorage-01'
+          });
           test.assertAnd(env.client.supportsRevs, true);
           test.done();
         }
@@ -309,7 +321,10 @@ define(['bluebird', 'requirejs', 'test/behavior/backend', 'test/helpers/mocks'],
       {
         desc: "#configure sets 'connected' to true, once href and token are given",
         run: function(env, test) {
-          env.client.configure(undefined, 'https://example.com/storage/test', undefined, 'foobarbaz');
+          env.client.configure({
+            href: 'https://example.com/storage/test',
+            token: 'foobarbaz'
+          });
           test.assert(env.client.connected, true);
         }
       },
@@ -368,7 +383,9 @@ define(['bluebird', 'requirejs', 'test/behavior/backend', 'test/helpers/mocks'],
       {
         desc: "#get doesn't set the 'If-None-Match' when revisions are supported and no rev given",
         run: function(env, test) {
-          env.connectedClient.configure(undefined, undefined, 'draft-dejong-remotestorage-01');
+          env.connectedClient.configure({
+            storageApi: 'draft-dejong-remotestorage-01'
+          });
           env.connectedClient.get('/foo/bar');
           var request = XMLHttpRequest.instances.shift();
           var hasIfNoneMatchHeader = request._headers.hasOwnProperty('If-None-Match');
@@ -379,7 +396,9 @@ define(['bluebird', 'requirejs', 'test/behavior/backend', 'test/helpers/mocks'],
       {
         desc: "#get sets the 'If-None-Match' to the given value, when revisions are supported and the ifNoneMatch option is provided",
         run: function(env, test) {
-          env.connectedClient.configure(undefined, undefined, 'draft-dejong-remotestorage-01');
+          env.connectedClient.configure({
+            storageApi: 'draft-dejong-remotestorage-01'
+          });
           env.connectedClient.get('/foo/bar', { ifNoneMatch: 'something' });
           var request = XMLHttpRequest.instances.shift();
           test.assert(request._headers['If-None-Match'], '"something"');
@@ -389,7 +408,9 @@ define(['bluebird', 'requirejs', 'test/behavior/backend', 'test/helpers/mocks'],
       {
         desc: "#get doesn't set the 'If-None-Match' header, when revisions are not supported",
         run: function(env, test) {
-          env.connectedClient.configure(undefined, undefined, 'https://www.w3.org/community/rww/wiki/read-write-web-00#simple');
+          env.connectedClient.configure({
+            storageApi: 'https://www.w3.org/community/rww/wiki/read-write-web-00#simple'
+          });
           env.connectedClient.get('/foo/bar');
           var request = XMLHttpRequest.instances.shift();
           test.assertType(request._headers['If-None-Match'], 'undefined');
@@ -399,7 +420,9 @@ define(['bluebird', 'requirejs', 'test/behavior/backend', 'test/helpers/mocks'],
       {
         desc: "#get doesn't set the 'If-None-Match' header even though the option is given, when revisions are not supported",
         run: function(env, test) {
-          env.connectedClient.configure(undefined, undefined, 'https://www.w3.org/community/rww/wiki/read-write-web-00#simple');
+          env.connectedClient.configure({
+            storageApi: 'https://www.w3.org/community/rww/wiki/read-write-web-00#simple'
+          });
           env.connectedClient.get('/foo/bar', { ifNoneMatch: 'something' });
           var request = XMLHttpRequest.instances.shift();
           test.assertType(request._headers['If-None-Match'], 'undefined');
@@ -541,7 +564,9 @@ define(['bluebird', 'requirejs', 'test/behavior/backend', 'test/helpers/mocks'],
       {
         desc: "#put encodes special characters in the path",
         run: function(env, test) {
-          env.connectedClient.configure(undefined, undefined, 'draft-dejong-remotestorage-01');
+          env.connectedClient.configure({
+            storageApi: 'draft-dejong-remotestorage-01'
+          });
           var request = RemoteStorage.WireClient.request;
 
           RemoteStorage.WireClient.request = function(method, url, options) {
@@ -558,7 +583,9 @@ define(['bluebird', 'requirejs', 'test/behavior/backend', 'test/helpers/mocks'],
       {
         desc: "#put encodes spaces in the path",
         run: function(env, test) {
-          env.connectedClient.configure(undefined, undefined, 'draft-dejong-remotestorage-01');
+          env.connectedClient.configure({
+            storageApi: 'draft-dejong-remotestorage-01'
+          });
           var request = RemoteStorage.WireClient.request;
 
           RemoteStorage.WireClient.request = function(method, url, options) {
@@ -575,7 +602,9 @@ define(['bluebird', 'requirejs', 'test/behavior/backend', 'test/helpers/mocks'],
       {
         desc: "#put leaves slash characters in the path",
         run: function(env, test) {
-          env.connectedClient.configure(undefined, undefined, 'draft-dejong-remotestorage-01');
+          env.connectedClient.configure({
+            storageApi: 'draft-dejong-remotestorage-01'
+          });
           var request = RemoteStorage.WireClient.request;
 
           RemoteStorage.WireClient.request = function(method, url, options) {
@@ -592,7 +621,9 @@ define(['bluebird', 'requirejs', 'test/behavior/backend', 'test/helpers/mocks'],
       {
         desc: "#put removes redundant slash characters in the path",
         run: function(env, test) {
-          env.connectedClient.configure(undefined, undefined, 'draft-dejong-remotestorage-01');
+          env.connectedClient.configure({
+            storageApi: 'draft-dejong-remotestorage-01'
+          });
           var request = RemoteStorage.WireClient.request;
 
           RemoteStorage.WireClient.request = function(method, url, options) {
@@ -609,7 +640,9 @@ define(['bluebird', 'requirejs', 'test/behavior/backend', 'test/helpers/mocks'],
       {
         desc: "#put doesn't set the 'If-None-Match' when revisions are supported and no rev given",
         run: function(env, test) {
-          env.connectedClient.configure(undefined, undefined, 'draft-dejong-remotestorage-01');
+          env.connectedClient.configure({
+            storageApi: 'draft-dejong-remotestorage-01'
+          });
           env.connectedClient.put('/foo/bar', 'baz', 'text/plain');
           var request = XMLHttpRequest.instances.shift();
           var hasIfNoneMatchHeader = request._headers.hasOwnProperty('If-None-Match');
@@ -620,7 +653,9 @@ define(['bluebird', 'requirejs', 'test/behavior/backend', 'test/helpers/mocks'],
       {
         desc: "#put doesn't set the 'If-Match' when revisions are supported and no rev given",
         run: function(env, test) {
-          env.connectedClient.configure(undefined, undefined, 'draft-dejong-remotestorage-01');
+          env.connectedClient.configure({
+            storageApi: 'draft-dejong-remotestorage-01'
+          });
           env.connectedClient.put('/foo/bar', 'baz', 'text/plain');
           var request = XMLHttpRequest.instances.shift();
           var hasIfMatchHeader = request._headers.hasOwnProperty('If-Match');
@@ -631,7 +666,9 @@ define(['bluebird', 'requirejs', 'test/behavior/backend', 'test/helpers/mocks'],
       {
         desc: "#delete doesn't set the 'If-Match' when revisions are supported and no rev given",
         run: function(env, test) {
-          env.connectedClient.configure(undefined, undefined, 'draft-dejong-remotestorage-01');
+          env.connectedClient.configure({
+            storageApi: 'draft-dejong-remotestorage-01'
+          });
           env.connectedClient.delete('/foo/bar');
           var request = XMLHttpRequest.instances.shift();
           var hasIfMatchHeader = request._headers.hasOwnProperty('If-Match');


### PR DESCRIPTION
This PR changes `RemoteStorage.Discover` to use promises instead of a callback. After this the only two places where callbacks are still used will be (if I grepped correctly), in readBinaryData and in the calls to IndexedDB (whose API we don't control).

It also changes the function signature of `remoteStorage.remote.configure` from having lots of separate arguments, to having an object with fields.

It also adds and updates some docs, and adds a test that was missing.

~~I can't run the tests locally atm, but let's hope Travis can :)~~ tests pass and quick test with myfavoritedrinks looks ok
