### PR TITLE
Switch from 'minifier' to 'minify' for build minification (fixes #817)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -41,7 +41,7 @@ compile-assets: $(ASSETS_OUT)
 
 %.min.js: %.js
 #	minify $< -o $@ --mangle --wrap --export-all
-	$(MINIFY_BIN) -o $@ $<
+	$(MINIFY_BIN) $< > $@
 	mv $@ $@.tmp
 	head -n1 $< > $@
 	cat $@.tmp >> $@

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
   "homepage": "http://remotestorage.io",
   "devDependencies": {
     "jaribu": "0.x.x",
-    "minifier": "^0.6.0"
+    "minify": "^1.4.0"
   },
   "scripts": {
     "test": "node_modules/jaribu/bin/jaribu"


### PR DESCRIPTION
This uses the 'minify' library (http://coderaiser.github.io/minify/), because the builds produced with 'minifier' (https://github.com/fizker/minifier) had a syntax error in Safari.

After merging this, you'll have to delete the `./node_modules` directory before running `npm install`. The command-line script in `./node_modoules/.bin/` has the same name as the previous one.