### PR TITLE
Use stateSetter function in widget error handling function (fixes #829)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ All releases can also be found and downloaded on the
 ### Bugfixes
 
 * Fix single quotes in filenames not working correctly (#812)
+* Fix broken AMD build (#816)
+* Fix console errors when using lib without widget (#829)
 
 ## 0.11.0 (October 2014)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 All releases can also be found and downloaded on the
 [releases page](https://github.com/remotestorage/remotestorage.js/releases) at GitHub.
 
-## 0.11.1-pre (November 2014)
+## 0.11.1-pre (January 2015, Hacker Beach Edition)
 
 ### Bugfixes
 

--- a/src/widget.js
+++ b/src/widget.js
@@ -189,14 +189,14 @@
     return function (error) {
       if (error instanceof RemoteStorage.DiscoveryError) {
         console.error('Discovery failed', error, '"' + error.message + '"');
-        widget.view.setState('initial', [error.message]);
+        stateSetter('initial', [error.message]);
       } else if (error instanceof RemoteStorage.SyncError) {
-        widget.view.setState('offline', []);
+        stateSetter('offline', []);
       } else if (error instanceof RemoteStorage.Unauthorized) {
-        widget.view.setState('unauthorized');
+        stateSetter('unauthorized');
       } else {
         RemoteStorage.log('[Widget] Unknown error');
-        widget.view.setState('error', [error]);
+        stateSetter('error', [error]);
       }
     };
   }


### PR DESCRIPTION
When not using the widget, there's no widget.view, so the direct setting of view state in the errorHandling function doesn't work. This makes it use the stateSetter helper function, which actually checks for
widget.view presence before trying to set properties on the view.