### PR TITLE
Fix bug introduced in recent syntax clean-up

### DIFF
--- a/src/remotestorage.js
+++ b/src/remotestorage.js
@@ -761,7 +761,7 @@
     },
 
     _dispatchEvent: function (eventName, event) {
-      this._pathHandlers[eventName].forEach(function (path) {
+      Object.keys(this._pathHandlers[eventName]).forEach(function (path) {
         var pl = path.length;
         var self = this;
         if (event.path.substr(0, pl) === path) {


### PR DESCRIPTION
This bug was introduced in the recent syntax cleanup session. It changes a line of code that handles objects into one that handles arrays. This is both fixing the line as well as refactoring the original one to be slighly nicer.