### PR TITLE
Switch from 'minifier' to 'uglifyjs' for build minification (fixes #817)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,7 @@ DOC_BIN        = naturaldocs
 DOC_DIR        = ./doc/code
 DOC_CONFIG_DIR = ./doc/config
 DOC_CUSTOM_CSS = custom-1
-MINIFY_BIN     = ./node_modules/.bin/minify
+UGLIFY_BIN     = ./node_modules/.bin/uglifyjs
 SOURCE_DIR     = ./src
 ASSETS_DIR     = ./assets
 ASSETS_OUT     = $(SOURCE_DIR)/assets.js
@@ -41,8 +41,7 @@ compile-assets: $(ASSETS_OUT)
 .PHONY: help buildserver build-all compile-assets minify build doc clean
 
 %.min.js: %.js
-#	minify $< -o $@ --mangle --wrap --export-all
-	$(MINIFY_BIN) -o $@ $<
+	$(UGLIFY_BIN) -c -o $@ $<
 	mv $@ $@.tmp
 	head -n1 $< > $@
 	cat $@.tmp >> $@

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
   "homepage": "http://remotestorage.io",
   "devDependencies": {
     "jaribu": "0.x.x",
-    "minifier": "^0.6.0"
+    "uglify-js": "^2.4.16"
   },
   "scripts": {
     "test": "node_modules/jaribu/bin/jaribu"


### PR DESCRIPTION
The filesize of the minified build is bigger than before, but at least there are no syntax errors. We might be able to make it smaller using some other options later.

This replaces the PR #824, the minified builds can still be run through other minifiers without breaking.