### PR TITLE
Check if FileReader instance can handle `addEventListener` call (closes #836)

### DIFF
--- a/src/wireclient.js
+++ b/src/wireclient.js
@@ -95,9 +95,15 @@
   function readBinaryData(content, mimeType, callback) {
     var blob = new Blob([content], { type: mimeType });
     var reader = new FileReader();
-    reader.addEventListener("loadend", function () {
-      callback(reader.result); // reader.result contains the contents of blob as a typed array
-    });
+    if (typeof reader.addEventListener === 'undefined') {
+      reader.onloadend = function() {
+        callback(reader.result); // reader.result contains the contents of blob as a typed array
+      }
+    } else {
+      reader.addEventListener("loadend", function () {
+        callback(reader.result); // reader.result contains the contents of blob as a typed array
+      });
+    }
     reader.readAsArrayBuffer(blob);
   }
 
@@ -109,9 +115,15 @@
     } else {
       var blob = new Blob([arrayBuffer]);
       var fileReader = new FileReader();
-      fileReader.addEventListener("loadend", function (evt) {
-        pending.resolve(evt.target.result);
-      });
+      if (typeof fileReader.addEventListener === 'undefined') {
+        fileReader.onloadend = function(evt) {
+          pending.resolve(evt.target.result);
+        }
+      } else {
+        fileReader.addEventListener("loadend", function (evt) {
+          pending.resolve(evt.target.result);
+        });
+      }
       fileReader.readAsText(blob, encoding);
     }
     return pending.promise;

--- a/src/wireclient.js
+++ b/src/wireclient.js
@@ -95,14 +95,14 @@
   function readBinaryData(content, mimeType, callback) {
     var blob = new Blob([content], { type: mimeType });
     var reader = new FileReader();
-    if (typeof reader.addEventListener === 'undefined') {
-      reader.onloadend = function() {
-        callback(reader.result); // reader.result contains the contents of blob as a typed array
-      }
-    } else {
+    if (typeof reader.addEventListener === 'function') {
       reader.addEventListener("loadend", function () {
         callback(reader.result); // reader.result contains the contents of blob as a typed array
       });
+    } else {
+      reader.onloadend = function() {
+        callback(reader.result); // reader.result contains the contents of blob as a typed array
+      }
     }
     reader.readAsArrayBuffer(blob);
   }
@@ -115,14 +115,14 @@
     } else {
       var blob = new Blob([arrayBuffer]);
       var fileReader = new FileReader();
-      if (typeof fileReader.addEventListener === 'undefined') {
-        fileReader.onloadend = function(evt) {
-          pending.resolve(evt.target.result);
-        }
-      } else {
+      if (typeof fileReader.addEventListener === 'function') {
         fileReader.addEventListener("loadend", function (evt) {
           pending.resolve(evt.target.result);
         });
+      } else {
+        fileReader.onloadend = function(evt) {
+          pending.resolve(evt.target.result);
+        }
       }
       fileReader.readAsText(blob, encoding);
     }


### PR DESCRIPTION
This PR fixes the error described in #836.

It checks if the FileReader instance has an `addEventListener` function. If it doesn't it sets the `onloadend` handler instead.