### PR TITLE
Fix widget not being set to correct modes in errorsHandler (refs #740)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ All releases can also be found and downloaded on the
 ### Bugfixes
 
 * Fix usage of FileReader that doesn't support `addEventListener` (#836)
+* Fix widget not being set to correct mode in some cases (e.g. offline) (#740)
 
 ## 0.11.1 (January 2015, Hacker Beach Edition)
 

--- a/src/widget.js
+++ b/src/widget.js
@@ -1,7 +1,7 @@
 (function (window) {
 
   var hasLocalStorage;
-  var LS_STATE_KEY = "remotestorage:widget:state";
+  var LS_STATE_KEY = 'remotestorage:widget:state';
 
   // states allowed to immediately jump into after a reload.
   var VALID_ENTRY_STATES = {
@@ -187,6 +187,7 @@
 
   function errorsHandler(widget) {
     return function (error) {
+      var s;
       if (error instanceof RemoteStorage.DiscoveryError) {
         console.error('Discovery failed', error, '"' + error.message + '"');
         s = stateSetter(widget, 'initial', [error.message]);

--- a/src/widget.js
+++ b/src/widget.js
@@ -189,15 +189,16 @@
     return function (error) {
       if (error instanceof RemoteStorage.DiscoveryError) {
         console.error('Discovery failed', error, '"' + error.message + '"');
-        stateSetter('initial', [error.message]);
+        s = stateSetter(widget, 'initial', [error.message]);
       } else if (error instanceof RemoteStorage.SyncError) {
-        stateSetter('offline', []);
+        s = stateSetter(widget, 'offline', []);
       } else if (error instanceof RemoteStorage.Unauthorized) {
-        stateSetter('unauthorized');
+        s = stateSetter(widget, 'unauthorized');
       } else {
         RemoteStorage.log('[Widget] Unknown error');
-        stateSetter('error', [error]);
+        s = stateSetter(widget, 'error', [error]);
       }
+      s.apply();
     };
   }
 


### PR DESCRIPTION
stateSetter actually returns a function instead of setting the state immediately, so it needs to be applied from errorsHandler.

You can try this by turning off your Internet connection and seeing that the widget actually goes into offline mode, as well as going back when turning the connection back on.

This is kind of urgent, because it's basically broken in all apps using >=0.11.0 so quick reviews would be helpful!