### PR TITLE
Don't use incompatible/buggy IndexedDB implementations (fixes #841)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ All releases can also be found and downloaded on the
 
 * Fix usage of FileReader that doesn't support `addEventListener` (#836)
 * Fix widget not being set to correct mode in some cases (e.g. offline) (#740)
+* Don't use incompatible/buggy IndexedDB implementations (#841)
 
 ## 0.11.1 (January 2015, Hacker Beach Edition)
 

--- a/src/indexeddb.js
+++ b/src/indexeddb.js
@@ -330,7 +330,21 @@
   RS.IndexedDB._rs_supported = function () {
     var pending = Promise.defer();
 
-    if ('indexedDB' in global) {
+    global.indexedDB = global.indexedDB    || global.webkitIndexedDB ||
+                       global.mozIndexedDB || global.oIndexedDB      ||
+                       global.msIndexedDB;
+
+    // Detect browsers with known IndexedDb issues (e.g. Android pre-4.4)
+    var poorIndexedDbSupport = false;
+    if (typeof global.navigator !== 'undefined' &&
+        global.navigator.userAgent.match(/Android (2|3|4\.[0-3])/)) {
+      // Chrome and Firefox support IndexedDB
+      if (!navigator.userAgent.match(/Chrome|Firefox/)) {
+        poorIndexedDbSupport = true;
+      }
+    }
+
+    if ('indexedDB' in global && !poorIndexedDbSupport) {
       try {
         var check = indexedDB.open("rs-check");
         check.onerror = function (event) {


### PR DESCRIPTION
This PR checks for Browsers with incompatible IndexedDB implementations (namely the stock Browser of all Android versions prior to 4.4).

I couldn't find any specific checks to detect problematic implementations, so I had to look for specific user agents. If anybody knows of better ways to do this, I would be glad to hear them.