### PR TITLE
udpated package dependencies, tests passing

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,16 +11,16 @@
   },
   "homepage": "http://remotestorage.io",
   "devDependencies": {
-    "jaribu": "0.x.x",
-    "uglify-js": "^2.4.16"
+    "jaribu": "^2.0.0",
+    "uglify-js": "^2.4.20"
   },
   "scripts": {
     "test": "node_modules/jaribu/bin/jaribu"
   },
   "dependencies": {
-    "bluebird": "^2.3.2",
-    "tv4": "^1.1.4",
-    "webfinger.js": "^2.0.5",
-    "xhr2": "0.0.7"
+    "bluebird": "^2.9.25",
+    "tv4": "^1.1.9",
+    "webfinger.js": "^2.1.4",
+    "xhr2": "^0.1.2"
   }
 }


### PR DESCRIPTION
updated `jaribu` to the `2.x` branch, which uses minimized output when tests are passing. Also updated the rest of the dependencies (no breaking changes, all tests passing).
