### PR TITLE
Fix maxAge being required/set when offline

### DIFF
--- a/src/remotestorage.js
+++ b/src/remotestorage.js
@@ -39,9 +39,10 @@
       var self = this;
       if (this.local) {
         if (maxAge === undefined) {
-          if (this.connected) {
+          if (this.remote.connected && this.remote.online) {
             maxAge = 2*this.getSyncInterval();
           } else {
+            RemoteStorage.log('Ignoring maxAge requirement, because remote is not connected or offline');
             maxAge = false;
           }
         }

--- a/src/sync.js
+++ b/src/sync.js
@@ -102,19 +102,15 @@
 
     queueGetRequest: function (path) {
       var pending = Promise.defer();
-      if (!this.remote.connected) {
-        pending.reject('cannot fulfill maxAge requirement - remote is not connected');
-      } else if (!this.remote.online) {
-        pending.reject('cannot fulfill maxAge requirement - remote is not online');
-      } else {
-        this.addTask(path, function () {
-          this.local.get(path).then(function (r) {
-            return pending.resolve(r);
-          });
-        }.bind(this));
 
-        this.doTasks();
-      }
+      this.addTask(path, function () {
+        this.local.get(path).then(function (r) {
+          return pending.resolve(r);
+        });
+      }.bind(this));
+
+      this.doTasks();
+
       return pending.promise;
     },
 

--- a/src/wireclient.js
+++ b/src/wireclient.js
@@ -373,7 +373,7 @@
       }
       if (this.href && this.token) {
         this.connected = true;
-        this.online = true;
+        this.online = false;
         this._emit('connected');
       } else {
         this.connected = false;


### PR DESCRIPTION
This fixes #849 by not requiring maxAge and failing otherwise, but ignoring maxAge when offline (while telling the dev in the remoteStorage logs about every ignored one). In essence, offline mode is pretty much broken without this fix.

Also, this sets `remoteStorage.remote.online` to `false` initially, so that the first request when starting up an app doesn't fail. This one is optional to merge and a problem in itself that we need to solve. Either way it's setting online or offline too late, causing issues with app starts.

Still to do:

* [ ] Tests
* [ ] Decide what to do with late online/offline state