### PR TITLE
Add optional token argument to connect() function

### DIFF
--- a/src/remotestorage.js
+++ b/src/remotestorage.js
@@ -311,13 +311,13 @@
      * Parameters:
      *   userAddress - The user address (user@host) to connect to.
      *
-     * Discovers the webfinger profile of the given user address and initiates
+     * Discovers the WebFinger profile of the given user address and initiates
      * the OAuth dance.
      *
      * This method must be called *after* all required access has been claimed.
      *
      */
-    connect: function (userAddress) {
+    connect: function (userAddress, token) {
       this.setBackend('remotestorage');
       if (userAddress.indexOf('@') < 0) {
         this._emit('error', new RemoteStorage.DiscoveryError("User address doesn't contain an @."));
@@ -341,13 +341,21 @@
         this.remote.configure(info);
         if (! this.remote.connected) {
           if (info.authURL) {
-            this.authorize(info.authURL);
+            if (typeof token === 'undefined') {
+              this.authorize(info.authURL);
+            } else {
+              RemoteStorage.log('Skipping authorization sequence and connecting with known token');
+              this.remote.configure({
+                token: token
+              });
+            }
           } else {
-            // In lieu of an excplicit authURL, assume that the browser
-            // and server handle any authorization needs; for instance,
-            // TLS may trigger the browser to use a client certificate,
-            // or a 401 Not Authorized response may make the browser
-            // send a Kerberos ticket using the SPNEGO method.
+            // In lieu of an excplicit authURL or when connecting with a token
+            // as argument (e.g. from node.js), assume that the browser and
+            // server handle any authorization needs; for instance, TLS may
+            // trigger the browser to use a client certificate, or a 401 Not
+            // Authorized response may make the browser send a Kerberos ticket
+            // using the SPNEGO method.
             this.impliedauth();
           }
         }

--- a/src/remotestorage.js
+++ b/src/remotestorage.js
@@ -342,12 +342,14 @@
         if (! this.remote.connected) {
           if (info.authURL) {
             if (typeof token === 'undefined') {
+              // Normal authorization step; the default way to connect
               this.authorize(info.authURL);
-            } else {
+            } else if (typeof token === 'string') {
+              // Token supplied directly by app/developer/user
               RemoteStorage.log('Skipping authorization sequence and connecting with known token');
-              this.remote.configure({
-                token: token
-              });
+              this.remote.configure({ token: token });
+            } else {
+              throw new Error("Supplied bearer token must be a string");
             }
           } else {
             // In lieu of an excplicit authURL, assume that the browser and

--- a/src/remotestorage.js
+++ b/src/remotestorage.js
@@ -350,8 +350,7 @@
               });
             }
           } else {
-            // In lieu of an excplicit authURL or when connecting with a token
-            // as argument (e.g. from node.js), assume that the browser and
+            // In lieu of an excplicit authURL, assume that the browser and
             // server handle any authorization needs; for instance, TLS may
             // trigger the browser to use a client certificate, or a 401 Not
             // Authorized response may make the browser send a Kerberos ticket


### PR DESCRIPTION
Sometimes, e.g. when using the library from node.js, it's useful to be able to use a known token when connecting a storage and skip the authorization part altogether.

With this change, it's possible connect by calling the function directly and with a token (from a program or console), like so:

```js
remoteStorage.connect('basti@5apps.com', '123456789abcdef');
```

I'm not sure how to test this best, as there are currently no tests or mocks for WebFinger and Discovery, other than throwing a couple errors when e.g. the user address doesn't look like one. That means implied auth is also untested at the moment, which is not ideal. However the code there is rather easy and straight-forward, and it's pretty hard to break it when only touching it once a year. So maybe it's fine for now.