### PR TITLE
Added an oauth flow for cordova using InAppBrowser

### DIFF
--- a/src/authorize.js
+++ b/src/authorize.js
@@ -46,7 +46,7 @@
         )
         .then(function (authResult) {
           remoteStorage.remote.configure({
-            token: authResult['access_token']
+            token: authResult.access_token
           });
 
           // sync doesnt start until after reload
@@ -71,24 +71,9 @@
       'http://localhost/callback' :
       String(RemoteStorage.Authorize.getLocation());
 
-    // not sure what to use as the id here
-    // don't see any good candidates in window.location on cordova android
-    // {
-    //  "ancestorOrigins": {
-    //   "length": 0
-    //  },
-    //  "origin": "file://",
-    //  "hash": "#/app/public/signup",
-    //  "search": "",
-    //  "pathname": "/android_asset/www/index.html",
-    //  "port": "",
-    //  "hostname": "",
-    //  "host": "",
-    //  "protocol": "file:",
-    //  "href": "file:///android_asset/www/index.html#/app/public/signup"
-    // }
-    // might need to request an clientId as input
     var clientId = global.cordova ?
+      // not guaranteed to be unique on cordova
+      // replace with a custom per-app clientId
       String(RemoteStorage.Authorize.getLocation()) :
       redirectUri.match(/^(https?:\/\/[^\/]+)/)[0];
 

--- a/src/authorize.js
+++ b/src/authorize.js
@@ -63,19 +63,15 @@
 
   RemoteStorage.Authorize.IMPLIED_FAKE_TOKEN = false;
 
-  RemoteStorage.prototype.authorize = function (authURL) {
+  RemoteStorage.prototype.authorize = function (authURL, cordovaRedirectUri) {
     this.access.setStorageType(this.remote.storageType);
     var scope = this.access.scopeParameter;
 
     var redirectUri = global.cordova ?
-      'http://localhost/callback' :
+      cordovaRedirectUri :
       String(RemoteStorage.Authorize.getLocation());
 
-    var clientId = global.cordova ?
-      // not guaranteed to be unique on cordova
-      // replace with a custom per-app clientId
-      String(RemoteStorage.Authorize.getLocation()) :
-      redirectUri.match(/^(https?:\/\/[^\/]+)/)[0];
+    var clientId = redirectUri.match(/^(https?:\/\/[^\/]+)/)[0];
 
     RemoteStorage.Authorize(authURL, scope, redirectUri, clientId);
   };

--- a/src/authorize.js
+++ b/src/authorize.js
@@ -46,7 +46,7 @@
         )
         .then(function (authResult) {
           remoteStorage.remote.configure({
-            token: authResult.access_token
+            token: authResult['access_token']
           });
 
           // sync doesnt start until after reload
@@ -131,7 +131,7 @@
       return pending.promise;
     }
 
-    var handleExit = function (event) {
+    var handleExit = function () {
       pending.reject('Authorization was canceled');
     };
 

--- a/src/remotestorage.js
+++ b/src/remotestorage.js
@@ -348,6 +348,7 @@
 
       if (global.cordova && !cordovaRedirectUri) {
         this._emit('error', new RemoteStorage.DiscoveryError("Please supply a custom HTTPS redirect URI for your Cordova app"));
+        return;
       }
 
       this.remote.configure({

--- a/src/remotestorage.js
+++ b/src/remotestorage.js
@@ -309,8 +309,8 @@
      * Connect to a remoteStorage server.
      *
      * Parameters:
-     *   userAddress - The user address (user@host) to connect to.
-     *   token       - (optional) A bearer token acquired beforehand
+     *   userAddress        - The user address (user@host) to connect to.
+     *   token              - (optional) A bearer token acquired beforehand
      *   cordovaRedirectUri - (optional) An HTTPS redirect URI for Cordova apps
      *
      * Discovers the WebFinger profile of the given user address and initiates


### PR DESCRIPTION
Here's a quick change I made to get remoteStorage to play well with Cordova. 

It's working for my app but I may be missing some corner cases. 

No new tests are failing as far as I can tell (there were some console errors when I ran the tests, both before and after my changes, but the summary says 0 failures). Let me know if you want to see any new tests written for this.

I referred heavily to the Dropbox Oauth implementation in ng-cordova-oauth:

https://github.com/nraboy/ng-cordova-oauth/blob/master/src/oauth.js

I made a small modification to reuse the existing extractParams function, and changed the redirectUri and clientId to be compatible with Cordova. 

I'm not sure what we can use for clientId in Cordova though. Nothing seems to be distinctive enough in window.location under Cordova (I've included a snapshot of what window.location looks like in my cordova app). Would it be a good idea to ask app developers for a clientId as an input for their app instead of generating it?