### PR TITLE
Do not set empty state parameter in authorize URI

### DIFF
--- a/src/authorize.js
+++ b/src/authorize.js
@@ -33,7 +33,7 @@
     url += 'redirect_uri=' + encodeURIComponent(redirectUri.replace(/#.*$/, ''));
     url += '&scope=' + encodeURIComponent(scope);
     url += '&client_id=' + encodeURIComponent(clientId);
-    if (hashPos !== -1) {
+    if (hashPos !== - 1 && hashPos+1 !== redirectUri.length) {
       url += '&state=' + encodeURIComponent(redirectUri.substring(hashPos+1));
     }
     url += '&response_type=token';

--- a/test/unit/authorize-suite.js
+++ b/test/unit/authorize-suite.js
@@ -78,6 +78,21 @@ define(['requirejs', 'fs'], function(requirejs, fs, undefined) {
       },
 
       {
+        desc: "Authorize redirects to the provider's OAuth location with empty fragment",
+        run: function(env, test) {
+          var authUrl = 'http://storage.provider.com/oauth';
+          var scope = 'contacts:r';
+          var redirectUri = 'http://awesome.app.com/#';
+          var clientId = 'http://awesome.app.com/';
+
+          RemoteStorage.Authorize(authUrl, scope, redirectUri, clientId);
+
+          var expectedUrl = 'http://storage.provider.com/oauth?redirect_uri=http%3A%2F%2Fawesome.app.com%2F&scope=contacts%3Ar&client_id=http%3A%2F%2Fawesome.app.com%2F&response_type=token';
+          test.assert(document.location.href, expectedUrl);
+        }
+      },
+    
+      {
         desc: "document.location getter",
         run: function(env, test) {
           test.assert(RemoteStorage.Authorize.getLocation().href, "http://foo/bar");


### PR DESCRIPTION
According to https://tools.ietf.org/html/rfc6749#appendix-A.5 an
empty state query parameter is not allowed. This can occur when
the authorize step is started when the application has a fragment
set, but no value in it, e.g. https://example.org/foo.html#.

Fix for issue #908