### PR TITLE
Fix duplicate logic implementation in isFolder

### DIFF
--- a/src/util.js
+++ b/src/util.js
@@ -107,7 +107,7 @@
     },
 
     isDocument: function (path) {
-      return path.substr(-1) !== '/';
+      return !RemoteStorage.util.isFolder(path);
     },
 
     baseName: function (path) {


### PR DESCRIPTION
A Document can never be a Folder and vice-versa. This is more future-proof.