### PR TITLE
Fix undefined remoteStorage when using it in cordova (#919)

### DIFF
--- a/src/authorize.js
+++ b/src/authorize.js
@@ -25,7 +25,7 @@
     document.location = redirectUri;
   };
 
-  RemoteStorage.Authorize = function (authURL, scope, redirectUri, clientId) {
+  RemoteStorage.Authorize = function (remoteStorage, authURL, scope, redirectUri, clientId) {
     RemoteStorage.log('[Authorize] authURL = ', authURL, 'scope = ', scope, 'redirectUri = ', redirectUri, 'clientId = ', clientId);
 
     var url = authURL, hashPos = redirectUri.indexOf('#');
@@ -75,7 +75,7 @@
 
     var clientId = redirectUri.match(/^(https?:\/\/[^\/]+)/)[0];
 
-    RemoteStorage.Authorize(authURL, scope, redirectUri, clientId);
+    RemoteStorage.Authorize(this, authURL, scope, redirectUri, clientId);
   };
 
   /**

--- a/test/unit/authorize-suite.js
+++ b/test/unit/authorize-suite.js
@@ -70,7 +70,7 @@ define(['requirejs', 'fs'], function(requirejs, fs, undefined) {
           var redirectUri = 'http://awesome.app.com/#custom/path';
           var clientId = 'http://awesome.app.com/';
 
-          RemoteStorage.Authorize(authUrl, scope, redirectUri, clientId);
+          RemoteStorage.Authorize(this, authUrl, scope, redirectUri, clientId);
 
           var expectedUrl = 'http://storage.provider.com/oauth?redirect_uri=http%3A%2F%2Fawesome.app.com%2F&scope=contacts%3Ar&client_id=http%3A%2F%2Fawesome.app.com%2F&state=custom%2Fpath&response_type=token';
           test.assert(document.location.href, expectedUrl);
@@ -85,7 +85,7 @@ define(['requirejs', 'fs'], function(requirejs, fs, undefined) {
           var redirectUri = 'http://awesome.app.com/#';
           var clientId = 'http://awesome.app.com/';
 
-          RemoteStorage.Authorize(authUrl, scope, redirectUri, clientId);
+          RemoteStorage.Authorize(this, authUrl, scope, redirectUri, clientId);
 
           var expectedUrl = 'http://storage.provider.com/oauth?redirect_uri=http%3A%2F%2Fawesome.app.com%2F&scope=contacts%3Ar&client_id=http%3A%2F%2Fawesome.app.com%2F&response_type=token';
           test.assert(document.location.href, expectedUrl);


### PR DESCRIPTION
When using remoteStorage.js with webpack , the remoteStorage vars isnt defined as it s not anymore available in scope. and remoteStorage is use for cordova compatibility.