### PR TITLE
Publish docs to gh-pages

### DIFF
--- a/doc/release_checklist.md
+++ b/doc/release_checklist.md
@@ -19,20 +19,10 @@
     * Go to https://github.com/remotestorage/remotestorage.js/tags and click "add release notes"
     * Use version string as title and changelog items as description
     * For RCs and betas, tick the "This is a pre-release" option on the bottom
+* Publish docs on GitHub Pages
+    * `./script/publish-docs`
 * Publish to npm (https://www.npmjs.org/package/remotestoragejs):
   * `npm publish`
-* Publish release on remotestorage.io
-    * `git up`
-    * While in the gh-pages branch:
-        * Copy the release from the remotestorage.js repo into `release/` dir
-        * `rm -rf doc/*`
-        * Copy `/doc/code` from remoteStorage.js repo to `doc/code`
-        * Commit changes to Git
-    * While back in master branch:
-        * Update version number, links, file size in `views/integrate/_hero.jade`
-        * Commit changes to Git
-        * Run `./deploy`
-        * `git push origin master`
 * Update https://github.com/remotestorage/myfavoritedrinks to use new release
     * Replace `remotestorage.js` with new release build
     * Check if everything is still working

--- a/scripts/publish-docs.sh
+++ b/scripts/publish-docs.sh
@@ -1,0 +1,14 @@
+#!/bin/bash
+
+make doc && \
+rm -rf tmp && \
+cp -R doc/code tmp && \
+rm -rf doc/code && \
+git checkout doc/config && \
+git checkout gh-pages && \
+cp -R tmp/* . && \
+rm -rf tmp && \
+git add . && \
+git commit -a -m "Update docs - `date -u`" && \
+git push origin gh-pages && \
+git checkout master

--- a/scripts/publish-docs.sh
+++ b/scripts/publish-docs.sh
@@ -1,14 +1,15 @@
 #!/bin/bash
+set -ex
 
-make doc && \
-rm -rf tmp && \
-cp -R doc/code tmp && \
-rm -rf doc/code && \
-git checkout doc/config && \
-git checkout gh-pages && \
-cp -R tmp/* . && \
-rm -rf tmp && \
-git add . && \
-git commit -a -m "Update docs - `date -u`" && \
-git push origin gh-pages && \
+make doc
+rm -rf tmp
+cp -R doc/code tmp
+rm -rf doc/code
+git checkout doc/config
+git checkout gh-pages
+cp -R tmp/* .
+rm -rf tmp
+git add .
+git commit -a -m "Update docs - `date -u`"
+git push origin gh-pages
 git checkout master


### PR DESCRIPTION
Adds the same script that is used in the modules repo in order to publish to gh-pages. I already published the current state, so I can link it on the new site/wiki:

https://remotestorage.github.io/remotestorage.js