### PR TITLE
Fix disconnect / initialization

### DIFF
--- a/src/authorize.js
+++ b/src/authorize.js
@@ -48,11 +48,6 @@
           remoteStorage.remote.configure({
             token: authResult.access_token
           });
-
-          // TODO
-          // sync doesn't start until after reload
-          // possibly missing some initialization step?
-          global.location.reload();
         })
         .then(null, function(error) {
           console.error(error);

--- a/src/eventhandling.js
+++ b/src/eventhandling.js
@@ -39,7 +39,7 @@
     _emit: function (eventName) {
       this._validateEvent(eventName);
       var args = Array.prototype.slice.call(arguments, 1);
-      this._handlers[eventName].forEach(function (handler) {
+      this._handlers[eventName].slice().forEach(function (handler) {
         handler.apply(this, args);
       });
     },

--- a/src/i18n.js
+++ b/src/i18n.js
@@ -40,7 +40,9 @@
 
     setDictionary: function (newDictionary) {
       dictionary = newDictionary;
-    }
+    },
 
+    _rs_init: function() {
+    }
   };
 })();

--- a/src/indexeddb.js
+++ b/src/indexeddb.js
@@ -373,6 +373,7 @@
           pending.reject();
         };
         check.onsuccess = function (event) {
+          check.result.close();
           indexedDB.deleteDatabase("rs-check");
           pending.resolve();
         };

--- a/src/remotestorage.js
+++ b/src/remotestorage.js
@@ -432,7 +432,7 @@
       if (n > 0) {
         this._cleanups.forEach(function (cleanup) {
           var cleanupResult = cleanup(this);
-          if (typeof(cleanup) === 'object' && typeof(cleanup.then) === 'function') {
+          if (typeof(cleanupResult) === 'object' && typeof(cleanupResult.then) === 'function') {
             cleanupResult.then(oneDone);
           } else {
             oneDone();

--- a/src/remotestorage.js
+++ b/src/remotestorage.js
@@ -609,6 +609,7 @@
     },
 
     _collectCleanupFunctions: function () {
+      this._cleanups = [];
       for (var i=0; i < this.features.length; i++) {
         var cleanup = this.features[i].cleanup;
         if (typeof(cleanup) === 'function') {

--- a/src/sync.js
+++ b/src/sync.js
@@ -1169,6 +1169,7 @@
   RemoteStorage.Sync._rs_cleanup = function (remoteStorage) {
     remoteStorage.stopSync();
     remoteStorage.removeEventListener('ready', syncCycleCb);
+    delete remoteStorage.sync;
   };
 
 })(typeof(window) !== 'undefined' ? window : global);

--- a/src/sync.js
+++ b/src/sync.js
@@ -1163,12 +1163,19 @@
       remoteStorage.syncCycle();
     };
 
+    syncOnConnect = function() {
+      remoteStorage.removeEventListener('connected', syncOnConnect);
+      remoteStorage.startSync();
+    };
+
     remoteStorage.on('ready', syncCycleCb);
+    remoteStorage.on('connected', syncOnConnect);
   };
 
   RemoteStorage.Sync._rs_cleanup = function (remoteStorage) {
     remoteStorage.stopSync();
     remoteStorage.removeEventListener('ready', syncCycleCb);
+    remoteStorage.removeEventListener('connected', syncOnConnect);
     delete remoteStorage.sync;
   };
 

--- a/test/unit/remotestorage-suite.js
+++ b/test/unit/remotestorage-suite.js
@@ -203,6 +203,32 @@ define(['bluebird', 'requirejs', 'tv4'], function (Promise, requirejs, tv4) {
       },
 
       {
+        desc: "#disconnect waits for cleanup promises to resolve before marking them as done",
+        run: function(env, test) {
+          var promiseResolved = false;
+
+          var promiseMock = {
+            then: function(callback) {
+              promiseResolved = true;
+              callback();
+            }
+          };
+
+          env.rs._cleanups = [function() { return promiseMock; }];
+
+          env.rs.on('disconnected', function() {
+            if (promiseResolved) {
+              test.done();
+            } else {
+              test.fail('Cleanup promise was not resolved.');
+            }
+          });
+
+          env.rs.disconnect();
+        }
+      },
+
+      {
         desc: "remote connected fires connected",
         run: function(env, test) {
           env.rs.on('connected', function() {

--- a/test/unit/sync-suite.js
+++ b/test/unit/sync-suite.js
@@ -151,6 +151,19 @@ define(['bluebird', 'test/helpers/mocks', 'requirejs'], function(Promise, mocks,
       },
 
       {
+        desc : "Sync adapter removes itself from remoteStorage instance after cleanup",
+        run : function(env, test) {
+          test.assertAnd(typeof env.rs.sync, "object", "sync is not defined");
+
+          RemoteStorage.Sync._rs_cleanup(env.rs);
+
+          test.assertAnd(typeof env.rs.sync, "undefined", "sync is still defined after cleanup");
+
+          test.done();
+        }
+      },
+
+      {
         desc: "Default sync interval",
         run: function(env, test) {
           test.assert(env.rs.getSyncInterval(), 10000);

--- a/test/unit/sync-suite.js
+++ b/test/unit/sync-suite.js
@@ -177,6 +177,19 @@ define(['bluebird', 'test/helpers/mocks', 'requirejs'], function(Promise, mocks,
       },
 
       {
+        desc : "Custom connected event handlers get called after Sync adapter removed its own handler",
+        run : function(env, test) {
+          RemoteStorage.Sync._rs_init(env.rs);
+
+          env.rs.on('connected', function() {
+            test.done();
+          });
+
+          env.rs._emit('connected');
+        }
+      },
+
+      {
         desc : "Sync adapter removes itself from remoteStorage instance after cleanup",
         run : function(env, test) {
           test.assertAnd(typeof env.rs.sync, "object", "sync is not defined");


### PR DESCRIPTION
refs #885

This bugfix is still work in progress.

It fixes problems when running `remoteStorage.disconnect()`, which prevented proper initialization and reconnection afterwards without reloading the Browser.

For some of the fixes there are still tests missing.

Also, there is still some timing issue which sometimes prevents the proper starting of the sync after calling configure (as described in the referenced issue).

