### PR TITLE
Fix getListing not rejecting promise when using illegal path

### DIFF
--- a/src/baseclient.js
+++ b/src/baseclient.js
@@ -219,7 +219,7 @@
       if (typeof(path) !== 'string') {
         path = '';
       } else if (path.length > 0 && path[path.length - 1] !== '/') {
-        Promise.reject("Not a folder: " + path);
+        return Promise.reject("Not a folder: " + path);
       }
       return this.storage.get(this.makePath(path), maxAge).then(
         function (r) {

--- a/test/unit/baseclient-suite.js
+++ b/test/unit/baseclient-suite.js
@@ -184,9 +184,12 @@ define(['bluebird', 'requirejs', 'test/helpers/mocks', 'tv4'], function (Promise
 
       {
         desc: "#getListing fails when it gets a document path",
-        willFail: true,
         run: function(env, test) {
-          return env.client.getListing('bar');
+          env.client.getListing('bar').then(function() {
+            test.result(false);
+          }, function(error) {
+            test.assert(error, 'Not a folder: bar');
+          });
         }
       },
 

--- a/test/unit/cachinglayer-suite.js
+++ b/test/unit/cachinglayer-suite.js
@@ -118,7 +118,6 @@ define(['bluebird', 'requirejs'], function (Promise, requirejs) {
         run: function (env, test) {
           env.ims.put('/foo/bar/baz/baf', 'asdf', 'qwer').then(function () {
             env.ims._getAllDescendentPaths('/').then(function (paths) {
-              console.log("paths: ",paths);
               test.assertAnd(paths.sort(), ['/', '/foo/', '/foo/bar/', '/foo/bar/baz/', '/foo/bar/baz/baf'].sort());
               test.done();
             });

--- a/test/unit/dropbox-suite.js
+++ b/test/unit/dropbox-suite.js
@@ -190,7 +190,6 @@ define(['bluebird', 'requirejs', 'test/behavior/backend', 'test/helpers/mocks'],
           env.connectedClient.get('/foo/bar');
           var request = XMLHttpRequest.instances.shift();
           test.assertTypeAnd(request, 'object');
-          console.log("REQUEST OPEN",request._open);
           test.assert(request._open,
                       ['GET', 'https://api-content.dropbox.com/1/files/auto/foo/bar', true]);
         }

--- a/test/unit/inmemorycaching-suite.js
+++ b/test/unit/inmemorycaching-suite.js
@@ -329,7 +329,6 @@ define(['bluebird', 'requirejs'], function (Promise, requirejs) {
           var getLatest = env.ims._getInternals().getLatest;
 
           return env.ims.put('/foo/bar/baz', 'bla', 'text/plain', 'a1b2c3').then(function (r) {
-            console.log('response: ', r);
             var storageKeys = ['/foo/bar/baz', '/foo/bar/', '/foo/', '/'];
 
             test.assertAnd(Object.keys(storage), storageKeys);


### PR DESCRIPTION
fixes #932 

Fixed by actually returning the rejected promise.

There even was a test that checked that `getListing` fails, but it failed for a different reason (network request didn't work).

I also cleaned up some debugging console logs from the test output.