### PR TITLE
Bugfix/934-unresolved promise

### DIFF
--- a/src/sync.js
+++ b/src/sync.js
@@ -286,7 +286,7 @@
 
         for (var i=1; i<paths.length; i++) {
           if (this._tasks[paths[i]]) {
-            if (this._tasks[path]) {
+            if (this._tasks[path].length) {
               Array.prototype.push.apply(
                 this._tasks[paths[i]],
                 this._tasks[path]

--- a/src/sync.js
+++ b/src/sync.js
@@ -286,7 +286,8 @@
 
         for (var i=1; i<paths.length; i++) {
           if (this._tasks[paths[i]]) {
-            if (this._tasks[path].length) {
+            // move pending promises to parent task
+            if (Array.isArray(this._tasks[path]) && this._tasks[path].length) {
               Array.prototype.push.apply(
                 this._tasks[paths[i]],
                 this._tasks[path]

--- a/src/sync.js
+++ b/src/sync.js
@@ -961,7 +961,7 @@
       }
       for (path in this._tasks) {
         if (!this._running[path]) {
-          this._timeStarted = this.now();
+          this._timeStarted[path] = this.now();
           this._running[path] = this.doTask(path);
           this._running[path].then(this.finishTask.bind(this));
           numAdded++;

--- a/src/sync.js
+++ b/src/sync.js
@@ -286,6 +286,12 @@
 
         for (var i=1; i<paths.length; i++) {
           if (this._tasks[paths[i]]) {
+            if (this._tasks[path]) {
+              Array.prototype.push.apply(
+                this._tasks[paths[i]],
+                this._tasks[path]
+              );
+            }
             delete this._tasks[path];
           }
         }

--- a/test/unit/sync-suite.js
+++ b/test/unit/sync-suite.js
@@ -249,16 +249,20 @@ define(['bluebird', 'test/helpers/mocks', 'requirejs'], function(Promise, mocks,
           });
         }
       },
-
       {
         desc: "collectRefreshTasks gives preference to caching parent",
         run: function(env, test) {
           var tmpForAllNodes = env.rs.local.forAllNodes;
           var tmpNow = env.rs.sync.now;
+          var fakeCallback = function() {};
 
           test.assertAnd(env.rs.sync._tasks, {});
           test.assertAnd(env.rs.sync._running, {});
 
+          env.rs.sync.addTask(
+            '/foo/ba/and/then/some/sub/path',
+            fakeCallback // should be passed to the ancestor when overruled
+          );
           env.rs.sync.now = function() {
             return 1234568654321;
           };
@@ -301,7 +305,7 @@ define(['bluebird', 'test/helpers/mocks', 'requirejs'], function(Promise, mocks,
 
           env.rs.sync.collectRefreshTasks().then(function() {
             test.assertAnd(env.rs.sync._tasks, {
-              '/foo/': [],
+              '/foo/': [fakeCallback], // inherited from task '/foo/ba/and/then/some/sub/path'
               '/read/access/': []
             });
             env.rs.local.forAllNodes = tmpForAllNodes;


### PR DESCRIPTION
fixes #934 

The problem appears when trying to get a remote unexisting file (on a subdirectory, with cache), then the associated promise is not resolved.

The reason is that the callback associated to the task is removed in the function ```deleteChildPathsFromTasks``` because a task to get the parent exists.

[Edit] Forgot to comment the solution though it is obvious: before deleting the child paths from the tasks, we pick the associated callbacks and add them to the parent path.

Seems to work fine now.

Also fixed what looks to me like a little slip in the ```_timeStarted``` assignment.