### PR TITLE
Fix errors in Safari private browsing mode

### DIFF
--- a/src/authorize.js
+++ b/src/authorize.js
@@ -23,7 +23,7 @@
 
         // remove rsDiscovery param
         stateValue = stateValue.slice(stateValue.indexOf('rsDiscovery='),
-                                      encodedData.lenth + 12);
+                                      encodedData.length + 12);
 
         if (stateValue.length > 0) {
           m['state'] = state;

--- a/src/authorize.js
+++ b/src/authorize.js
@@ -26,7 +26,7 @@
                                       encodedData.length + 12);
 
         if (stateValue.length > 0) {
-          params['state'] = state;
+          params['state'] = stateValue;
         }
       } else {
         params[decodeURIComponent(kv[0])] = decodeURIComponent(kv[1]);

--- a/src/authorize.js
+++ b/src/authorize.js
@@ -22,8 +22,7 @@
         params['rsDiscovery'] = JSON.parse(atob(encodedData));
 
         // remove rsDiscovery param
-        stateValue = stateValue.slice(stateValue.indexOf('rsDiscovery='),
-                                      encodedData.length + 12);
+        stateValue = stateValue.replace(new RegExp('\&?rsDiscovery=' + encodedData), '');
 
         if (stateValue.length > 0) {
           params['state'] = stateValue;

--- a/src/authorize.js
+++ b/src/authorize.js
@@ -205,7 +205,8 @@
           authParamsUsed = true;
         }
         if (params.state) {
-          RemoteStorage.Authorize.setLocation('#'+params.state);
+          location = RemoteStorage.Authorize.getLocation();
+          RemoteStorage.Authorize.setLocation(location.href.split('#')[0]+'#'+params.state);
         }
       }
       if (!authParamsUsed) {

--- a/src/authorize.js
+++ b/src/authorize.js
@@ -9,7 +9,7 @@
     hash = location.substring(hashPos+1);
     // if hash is not of the form #key=val&key=val, it's probably not for us
     if (hash.indexOf('=') === -1) { return; }
-    return hash.split('&').reduce(function (m, kvs) {
+    return hash.split('&').reduce(function (params, kvs) {
       var kv = kvs.split('=');
 
       if (kv[0] === 'state' && kv[1].match(/rsDiscovery/)) {
@@ -19,20 +19,20 @@
                                     .split('&')[0]
                                     .split('=')[1];
 
-        m['rsDiscovery'] = JSON.parse(atob(encodedData));
+        params['rsDiscovery'] = JSON.parse(atob(encodedData));
 
         // remove rsDiscovery param
         stateValue = stateValue.slice(stateValue.indexOf('rsDiscovery='),
                                       encodedData.length + 12);
 
         if (stateValue.length > 0) {
-          m['state'] = state;
+          params['state'] = state;
         }
       } else {
-        m[decodeURIComponent(kv[0])] = decodeURIComponent(kv[1]);
+        params[decodeURIComponent(kv[0])] = decodeURIComponent(kv[1]);
       }
 
-      return m;
+      return params;
     }, {});
   }
 

--- a/src/authorize.js
+++ b/src/authorize.js
@@ -49,7 +49,7 @@
     RemoteStorage.log('[Authorize] authURL = ', authURL, 'scope = ', scope, 'redirectUri = ', redirectUri, 'clientId = ', clientId);
 
     // keep track of the discovery data during redirect if we can't save it in localStorage
-    if (!remoteStorage.localStorageAvailable()) {
+    if (!remoteStorage.localStorageAvailable() && remoteStorage.backend === 'remotestorage') {
       redirectUri += redirectUri.indexOf('#') > 0 ? '&' : '#';
 
       var discoveryData = {

--- a/src/authorize.js
+++ b/src/authorize.js
@@ -49,7 +49,8 @@
     RemoteStorage.log('[Authorize] authURL = ', authURL, 'scope = ', scope, 'redirectUri = ', redirectUri, 'clientId = ', clientId);
 
     // keep track of the discovery data during redirect if we can't save it in localStorage
-    if (!remoteStorage.localStorageAvailable() && remoteStorage.backend === 'remotestorage') {
+    if (!RemoteStorage.util.localStorageAvailable() &&
+        remoteStorage.backend === 'remotestorage') {
       redirectUri += redirectUri.indexOf('#') > 0 ? '&' : '#';
 
       var discoveryData = {

--- a/src/discover.js
+++ b/src/discover.js
@@ -73,7 +73,7 @@
   };
 
   RemoteStorage.Discover._rs_init = function (remoteStorage) {
-    hasLocalStorage = remoteStorage.localStorageAvailable();
+    hasLocalStorage = RemoteStorage.util.localStorageAvailable();
     if (hasLocalStorage) {
       var settings;
       try { settings = JSON.parse(localStorage[SETTINGS_KEY]); } catch(e) {}

--- a/src/dropbox.js
+++ b/src/dropbox.js
@@ -885,7 +885,7 @@
   }
 
   RS.Dropbox._rs_init = function (rs) {
-    hasLocalStorage = rs.localStorageAvailable();
+    hasLocalStorage = RemoteStorage.util.localStorageAvailable();
     if ( rs.apiKeys.dropbox ) {
       rs.dropbox = new RS.Dropbox(rs);
     }

--- a/src/localstorage.js
+++ b/src/localstorage.js
@@ -90,7 +90,15 @@
   RemoteStorage.LocalStorage._rs_init = function () {};
 
   RemoteStorage.LocalStorage._rs_supported = function () {
-    return 'localStorage' in global;
+    if (!('localStorage' in global)) { return false }
+
+    try {
+      global.localStorage.setItem('rs-check', 1);
+      global.localStorage.removeItem('rs-check');
+      return true;
+    } catch(error) {
+      return false;
+    }
   };
 
   // TODO tests missing!

--- a/src/localstorage.js
+++ b/src/localstorage.js
@@ -90,15 +90,7 @@
   RemoteStorage.LocalStorage._rs_init = function () {};
 
   RemoteStorage.LocalStorage._rs_supported = function () {
-    if (!('localStorage' in global)) { return false }
-
-    try {
-      global.localStorage.setItem('rs-check', 1);
-      global.localStorage.removeItem('rs-check');
-      return true;
-    } catch(error) {
-      return false;
-    }
+    return RemoteStorage.util.localStorageAvailable();
   };
 
   // TODO tests missing!

--- a/src/remotestorage.js
+++ b/src/remotestorage.js
@@ -195,7 +195,7 @@
 
     if (this.localStorageAvailable()) {
       try {
-        this.apiKeys = JSON.parse(localStorage.getItem('remotestorage:api-keys'));
+        this.apiKeys = JSON.parse(localStorage.getItem('remotestorage:api-keys')) || {};
       } catch(exc) {
         // ignored
       }

--- a/src/remotestorage.js
+++ b/src/remotestorage.js
@@ -195,11 +195,11 @@
 
     if (this.localStorageAvailable()) {
       try {
-        this.apiKeys = JSON.parse(localStorage['remotestorage:api-keys']);
+        this.apiKeys = JSON.parse(localStorage.getItem('remotestorage:api-keys'));
       } catch(exc) {
         // ignored
       }
-      this.setBackend(localStorage['remotestorage:backend'] || 'remotestorage');
+      this.setBackend(localStorage.getItem('remotestorage:backend') || 'remotestorage');
     }
 
     var origOn = this.on;
@@ -447,9 +447,9 @@
       this.backend = what;
       if (this.localStorageAvailable()) {
         if (what) {
-          localStorage['remotestorage:backend'] = what;
+          localStorage.setItem('remotestorage:backend', what);
         } else {
-          delete localStorage['remotestorage:backend'];
+          localStorage.removeItem('remotestorage:backend');
         }
       }
     },
@@ -523,7 +523,7 @@
         delete this.apiKeys[type];
       }
       if (this.localStorageAvailable()) {
-        localStorage['remotestorage:api-keys'] = JSON.stringify(this.apiKeys);
+        localStorage.setItem('remotestorage:api-keys', JSON.stringify(this.apiKeys));
       }
     },
 
@@ -763,8 +763,12 @@
     },
 
     localStorageAvailable: function () {
+      if (!('localStorage' in global)) { return false }
+
       try {
-        return !!global.localStorage;
+        global.localStorage.setItem('rs-check', 1);
+        global.localStorage.removeItem('rs-check');
+        return true;
       } catch(error) {
         return false;
       }

--- a/src/remotestorage.js
+++ b/src/remotestorage.js
@@ -1,5 +1,7 @@
 (function (global) {
 
+  var hasLocalStorage;
+
   // wrapper to implement defer() functionality
   Promise.defer = function () {
     var resolve, reject;
@@ -193,7 +195,9 @@
 
     this.apiKeys = {};
 
-    if (this.localStorageAvailable()) {
+    hasLocalStorage = RemoteStorage.util.localStorageAvailable();
+
+    if (hasLocalStorage) {
       try {
         this.apiKeys = JSON.parse(localStorage.getItem('remotestorage:api-keys')) || {};
       } catch(exc) {
@@ -445,7 +449,7 @@
 
     setBackend: function (what) {
       this.backend = what;
-      if (this.localStorageAvailable()) {
+      if (hasLocalStorage) {
         if (what) {
           localStorage.setItem('remotestorage:backend', what);
         } else {
@@ -522,7 +526,7 @@
       } else {
         delete this.apiKeys[type];
       }
-      if (this.localStorageAvailable()) {
+      if (hasLocalStorage) {
         localStorage.setItem('remotestorage:api-keys', JSON.stringify(this.apiKeys));
       }
     },
@@ -760,18 +764,6 @@
         }
       }
       return false;
-    },
-
-    localStorageAvailable: function () {
-      if (!('localStorage' in global)) { return false }
-
-      try {
-        global.localStorage.setItem('rs-check', 1);
-        global.localStorage.removeItem('rs-check');
-        return true;
-      } catch(error) {
-        return false;
-      }
     },
 
     /**

--- a/src/util.js
+++ b/src/util.js
@@ -401,8 +401,22 @@
       }
 
       return md5(str);
-    }
+    },
     /* jshint ignore:end */
+
+
+    localStorageAvailable: function() {
+      if (!('localStorage' in global)) { return false }
+
+      try {
+        global.localStorage.setItem('rs-check', 1);
+        global.localStorage.removeItem('rs-check');
+        return true;
+      } catch(error) {
+        return false;
+      }
+    }
+
   };
 
   if (!RemoteStorage.prototype.util) {

--- a/src/util.js
+++ b/src/util.js
@@ -4,7 +4,7 @@
  * Provides reusable utility functions at RemoteStorage.util
  *
  */
-(function () {
+(function (global) {
 
   /**
    * Function: fixArrayBuffers
@@ -427,4 +427,4 @@
       }
     });
   }
-})();
+})(typeof(window) !== 'undefined' ? window : global);

--- a/src/widget.js
+++ b/src/widget.js
@@ -157,7 +157,7 @@
   };
 
   RemoteStorage.Widget._rs_init = function (remoteStorage) {
-    hasLocalStorage = remoteStorage.localStorageAvailable();
+    hasLocalStorage = RemoteStorage.util.localStorageAvailable();
     if (! remoteStorage.widget) {
       remoteStorage.widget = new RemoteStorage.Widget(remoteStorage);
     }

--- a/src/wireclient.js
+++ b/src/wireclient.js
@@ -556,7 +556,7 @@
 
 
   RS.WireClient._rs_init = function (remoteStorage) {
-    hasLocalStorage = remoteStorage.localStorageAvailable();
+    hasLocalStorage = RemoteStorage.util.localStorageAvailable();
     remoteStorage.remote = new RS.WireClient(remoteStorage);
     this.online = true;
   };

--- a/test/unit/authorize-suite.js
+++ b/test/unit/authorize-suite.js
@@ -10,11 +10,19 @@ define(['requirejs', 'fs'], function(requirejs, fs, undefined) {
     setup: function(env, test) {
       global.RemoteStorage = function() {};
       RemoteStorage.log = function() {};
+
       require('./src/eventhandling');
       if (global.rs_eventhandling) {
         RemoteStorage.eventHandling = global.rs_eventhandling;
       } else {
         global.rs_eventhandling = RemoteStorage.eventHandling;
+      }
+
+      require('src/util');
+      if (global.rs_util) {
+        RemoteStorage.util = global.rs_util;
+      } else {
+        global.rs_util = RemoteStorage.util;
       }
 
       require('./src/authorize');

--- a/test/unit/authorize-suite.js
+++ b/test/unit/authorize-suite.js
@@ -70,6 +70,8 @@ define(['requirejs', 'fs'], function(requirejs, fs, undefined) {
           var redirectUri = 'http://awesome.app.com/#custom/path';
           var clientId = 'http://awesome.app.com/';
 
+          this.localStorageAvailable = function() { return true; };
+
           RemoteStorage.Authorize(this, authUrl, scope, redirectUri, clientId);
 
           var expectedUrl = 'http://storage.provider.com/oauth?redirect_uri=http%3A%2F%2Fawesome.app.com%2F&scope=contacts%3Ar&client_id=http%3A%2F%2Fawesome.app.com%2F&state=custom%2Fpath&response_type=token';
@@ -85,13 +87,15 @@ define(['requirejs', 'fs'], function(requirejs, fs, undefined) {
           var redirectUri = 'http://awesome.app.com/#';
           var clientId = 'http://awesome.app.com/';
 
+          this.localStorageAvailable = function() { return true; };
+
           RemoteStorage.Authorize(this, authUrl, scope, redirectUri, clientId);
 
           var expectedUrl = 'http://storage.provider.com/oauth?redirect_uri=http%3A%2F%2Fawesome.app.com%2F&scope=contacts%3Ar&client_id=http%3A%2F%2Fawesome.app.com%2F&response_type=token';
           test.assert(document.location.href, expectedUrl);
         }
       },
-    
+
       {
         desc: "document.location getter",
         run: function(env, test) {

--- a/test/unit/authorize-suite.js
+++ b/test/unit/authorize-suite.js
@@ -163,7 +163,7 @@ define(['requirejs', 'fs'], function(requirejs, fs, undefined) {
           };
           storage._handlers['features-loaded'][0]();
 
-          test.assert(document.location.href, '#custom/path');
+          test.assert(document.location.href, 'http://foo/bar#custom/path');
         }
       },
 

--- a/test/unit/discover-suite.js
+++ b/test/unit/discover-suite.js
@@ -15,6 +15,14 @@ define(['bluebird', 'requirejs', 'fs', 'webfinger.js'], function (Promise, requi
       global.RemoteStorage = function() {};
       RemoteStorage.log = function() {};
       global.RemoteStorage.prototype.localStorageAvailable = function() { return false; };
+
+      require('src/util');
+      if (global.rs_util) {
+        RemoteStorage.util = global.rs_util;
+      } else {
+        global.rs_util = RemoteStorage.util;
+      }
+
       require('./src/discover');
       if (global.rs_util) {
         RemoteStorage.discover = global.rs_discover;

--- a/test/unit/localstorage-suite.js
+++ b/test/unit/localstorage-suite.js
@@ -229,6 +229,23 @@ define(['bluebird', 'requirejs'], function (Promise, requirejs) {
         }
       },
 
+      {
+        desc: "#_rs_supported is false when writing to localStorage throws an error",
+        run: function(env, test) {
+          var QuotaExceededError = function(message) {
+            this.name = 'QuotaExceededError';
+            this.message = message;
+          };
+          QuotaExceededError.prototype = new Error();
+
+          localStorage.setItem = function(key, value) {
+            throw new QuotaExceededError('DOM exception 22');
+          }
+
+          test.assert(RemoteStorage.LocalStorage._rs_supported(), false);
+        }
+      },
+
       // TODO belongs in separate examples; missing description
       {
         desc: "getNodes, setNodes",

--- a/test/unit/modules-suite.js
+++ b/test/unit/modules-suite.js
@@ -24,6 +24,13 @@ define([], function() {
         global.rs_eventhandling = RemoteStorage.eventHandling;
       }
 
+      require('src/util');
+      if (global.rs_util) {
+        RemoteStorage.util = global.rs_util;
+      } else {
+        global.rs_util = RemoteStorage.util;
+      }
+
       RemoteStorage.prototype.remote = {
         connected: false
       };

--- a/test/unit/remotestorage-suite.js
+++ b/test/unit/remotestorage-suite.js
@@ -185,9 +185,21 @@ define(['bluebird', 'requirejs', 'tv4'], function (Promise, requirejs, tv4) {
       {
         desc: "#connect sets the backend to remotestorage",
         run: function(env, test) {
-          global.localStorage = {};
+          global.localStorage = {
+            storage: {},
+            setItem: function(key, value) {
+              this.storage[key] = value;
+            },
+            getItem: function(key) {
+              return this.storage[key];
+            },
+            removeItem: function(key) {
+              delete this.storage[key];
+            }
+          };
+
           env.rs.connect('user@ho.st');
-          test.assert(localStorage, {'remotestorage:backend': 'remotestorage'});
+          test.assert(localStorage.getItem('remotestorage:backend'), 'remotestorage');
         }
       },
 
@@ -224,6 +236,23 @@ define(['bluebird', 'requirejs', 'tv4'], function (Promise, requirejs, tv4) {
           });
 
           env.rs.disconnect();
+        }
+      },
+
+      {
+        desc: "#localStorageAvailable is false when saving items throws an error",
+        run: function(env, test) {
+          var QuotaExceededError = function(message) {
+            this.name = 'QuotaExceededError';
+            this.message = message;
+          };
+          QuotaExceededError.prototype = new Error();
+
+          localStorage.setItem = function(key, value) {
+            throw new QuotaExceededError('DOM exception 22');
+          }
+
+          test.assert(env.rs.localStorageAvailable(), false);
         }
       },
 

--- a/test/unit/remotestorage-suite.js
+++ b/test/unit/remotestorage-suite.js
@@ -74,12 +74,21 @@ define(['bluebird', 'requirejs', 'tv4'], function (Promise, requirejs, tv4) {
       } else {
         global.rs_rs = RemoteStorage;
       }
+
       require('./src/eventhandling.js');
       if (global.rs_eventhandling) {
         RemoteStorage.eventHandling = global.rs_eventhandling;
       } else {
         global.rs_eventhandling = RemoteStorage.eventHandling;
       }
+
+      require('src/util');
+      if (global.rs_util) {
+        RemoteStorage.util = global.rs_util;
+      } else {
+        global.rs_util = RemoteStorage.util;
+      }
+
       RemoteStorage.Discover = function(userAddress) {
         var pending = Promise.defer();
         if (userAddress === "someone@somewhere") {
@@ -198,6 +207,8 @@ define(['bluebird', 'requirejs', 'tv4'], function (Promise, requirejs, tv4) {
             }
           };
 
+          env.rs = new RemoteStorage();
+
           env.rs.connect('user@ho.st');
           test.assert(localStorage.getItem('remotestorage:backend'), 'remotestorage');
         }
@@ -236,23 +247,6 @@ define(['bluebird', 'requirejs', 'tv4'], function (Promise, requirejs, tv4) {
           });
 
           env.rs.disconnect();
-        }
-      },
-
-      {
-        desc: "#localStorageAvailable is false when saving items throws an error",
-        run: function(env, test) {
-          var QuotaExceededError = function(message) {
-            this.name = 'QuotaExceededError';
-            this.message = message;
-          };
-          QuotaExceededError.prototype = new Error();
-
-          localStorage.setItem = function(key, value) {
-            throw new QuotaExceededError('DOM exception 22');
-          }
-
-          test.assert(env.rs.localStorageAvailable(), false);
         }
       },
 

--- a/test/unit/util-suite.js
+++ b/test/unit/util-suite.js
@@ -164,9 +164,11 @@ define(['bluebird', 'requirejs'], function (Promise, requirejs) {
           };
           QuotaExceededError.prototype = new Error();
 
-          localStorage.setItem = function(key, value) {
-            throw new QuotaExceededError('DOM exception 22');
-          }
+          global.localStorage = {
+            setItem: function(key, value) {
+              throw new QuotaExceededError('DOM exception 22');
+            }
+          };
 
           test.assert(RemoteStorage.util.localStorageAvailable(), false);
         }

--- a/test/unit/util-suite.js
+++ b/test/unit/util-suite.js
@@ -153,7 +153,25 @@ define(['bluebird', 'requirejs'], function (Promise, requirejs) {
           var md5sum = RemoteStorage.util.md5sum('this is a very happy string');
           test.assert(md5sum, '962e9575a9eba5bfedbad85cf125da20');
         }
+      },
+
+      {
+        desc: "localStorageAvailable is false when saving items throws an error",
+        run: function(env, test) {
+          var QuotaExceededError = function(message) {
+            this.name = 'QuotaExceededError';
+            this.message = message;
+          };
+          QuotaExceededError.prototype = new Error();
+
+          localStorage.setItem = function(key, value) {
+            throw new QuotaExceededError('DOM exception 22');
+          }
+
+          test.assert(RemoteStorage.util.localStorageAvailable(), false);
+        }
       }
+
     ]
   });
 


### PR DESCRIPTION
closes #921

In Safari private browsing mode, writing to locaStorage throws an `QuotaExceededError` error.

This change tries to set an item for checking if localStorage is available.