### PR TITLE
(Re)initialize 3rd party backend when setting API key

### DIFF
--- a/src/remotestorage.js
+++ b/src/remotestorage.js
@@ -519,6 +519,13 @@
     setApiKeys: function (type, keys) {
       if (keys) {
         this.apiKeys[type] = keys;
+        if (type === 'dropbox' && (typeof this.dropbox === 'undefined' ||
+                                   this.dropbox.clientId !== keys.appKey)) {
+          RemoteStorage.Dropbox._rs_init(this);
+        } else if (type === 'googledrive' && (typeof this.googledrive === 'undefined' ||
+                                              this.googledrive.clientId !== keys.clientId)) {
+          RemoteStorage.GoogleDrive._rs_init(this);
+        }
       } else {
         delete this.apiKeys[type];
       }

--- a/test/unit/remotestorage-suite.js
+++ b/test/unit/remotestorage-suite.js
@@ -173,6 +173,54 @@ define(['bluebird', 'requirejs', 'tv4'], function (Promise, requirejs, tv4) {
       },
 
       {
+        desc: "#setApiKeys initializes the configured backend when it's not initialized yet",
+        run: function(env, test) {
+          RemoteStorage.Dropbox = {
+            _rs_init: function(remoteStorage) {
+              test.done();
+            }
+          }
+
+          env.rs.setApiKeys('dropbox', { appKey: 'testkey' });
+        }
+      },
+
+      {
+        desc: "#setApiKeys reinitializes the configured backend when the key changed",
+        run: function(env, test) {
+          env.rs.dropbox = {
+            clientId: 'old key'
+          };
+
+          RemoteStorage.Dropbox = {
+            _rs_init: function(remoteStorage) {
+              test.done();
+            }
+          }
+
+          env.rs.setApiKeys('dropbox', { appKey: 'new key' });
+        }
+      },
+
+      {
+        desc: "#setApiKeys does not reinitialize the configured backend when key didn't change",
+        run: function(env, test) {
+          env.rs.dropbox = {
+            clientId: 'old key'
+          };
+
+          RemoteStorage.Dropbox = {
+            _rs_init: function(remoteStorage) {
+              test.fail('Backend got reinitialized again although the key did not change.');
+            }
+          }
+
+          env.rs.setApiKeys('dropbox', { appKey: 'old key' });
+          test.done();
+        }
+      },
+
+      {
         desc: "#connect throws unauthorized when userAddress doesn't contain an @",
         run: function(env, test) {
           env.rs.on('error', function(e) {


### PR DESCRIPTION
fixes #941

This fixes an issue where the backends wouldn't be initialized when the key was not already saved in localStorage before or the key is different from the one in localStorage.