### PR TITLE
Fix discovery errors (and others) not being thrown/shown

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
   "dependencies": {
     "bluebird": "^3.0.5",
     "tv4": "^1.2.7",
-    "webfinger.js": "^2.2.1",
+    "webfinger.js": "^2.4.2",
     "xhr2": "^0.1.3"
   }
 }

--- a/src/discover.js
+++ b/src/discover.js
@@ -45,7 +45,7 @@
 
     webFinger.lookup(userAddress, function (err, response) {
       if (err) {
-        return pending.reject(err.message);
+        return pending.reject(err);
       } else if ((typeof response.idx.links.remotestorage !== 'object') ||
                  (typeof response.idx.links.remotestorage.length !== 'number') ||
                  (response.idx.links.remotestorage.length <= 0)) {

--- a/src/remotestorage.js
+++ b/src/remotestorage.js
@@ -364,7 +364,7 @@
       this._emit('connecting');
 
       var discoveryTimeout = setTimeout(function () {
-        this._emit('error', new RemoteStorage.DiscoveryError("No storage information found at that user address."));
+        this._emit('error', new RemoteStorage.DiscoveryError("No storage information found for this user address."));
       }.bind(this), RemoteStorage.config.discoveryTimeout);
 
       RemoteStorage.Discover(userAddress).then(function (info) {
@@ -396,7 +396,8 @@
           }
         }
       }.bind(this), function(err) {
-        this._emit('error', new RemoteStorage.DiscoveryError("Failed to contact storage server."));
+        clearTimeout(discoveryTimeout);
+        this._emit('error', new RemoteStorage.DiscoveryError("No storage information found for this user address."));
       }.bind(this));
     },
 

--- a/src/view.js
+++ b/src/view.js
@@ -68,13 +68,13 @@
      *   state
      *   args
      **/
-    setState: function (state, args) {
-      RemoteStorage.log('[View] widget.view.setState(',state,',',args,');');
+    setState: function (state, message) {
+      RemoteStorage.log('[View] widget.view.setState(',state,',',message,');');
       var s = this.states[state];
       if (typeof(s) === 'undefined') {
         throw new Error("Bad State assigned to view: " + state);
       }
-      s.apply(this, args);
+      s.apply(this, [message]);
     },
 
     /**

--- a/src/widget.js
+++ b/src/widget.js
@@ -167,10 +167,10 @@
     return typeof(document) !== 'undefined';
   };
 
-  function stateSetter(widget, state) {
+  function stateSetter(widget, state, message) {
     RemoteStorage.log('[Widget] Producing stateSetter for', state);
     return function () {
-      RemoteStorage.log('[Widget] Setting state', state, arguments);
+      RemoteStorage.log('[Widget] Setting state', state, message);
       if (hasLocalStorage) {
         localStorage[LS_STATE_KEY] = state;
       }
@@ -178,7 +178,7 @@
         if (widget.rs.remote) {
           widget.view.setUserAddress(widget.rs.remote.userAddress);
         }
-        widget.view.setState(state, arguments);
+        widget.view.setState(state, message);
       } else {
         widget._rememberedState = state;
       }
@@ -190,9 +190,9 @@
       var s;
       if (error instanceof RemoteStorage.DiscoveryError) {
         console.error('Discovery failed', error, '"' + error.message + '"');
-        s = stateSetter(widget, 'initial', [error.message]);
+        s = stateSetter(widget, 'initial', error.message);
       } else if (error instanceof RemoteStorage.SyncError) {
-        s = stateSetter(widget, 'offline', []);
+        s = stateSetter(widget, 'offline');
       } else if (error instanceof RemoteStorage.Unauthorized) {
         s = stateSetter(widget, 'unauthorized');
       } else {

--- a/test/unit/discover-suite.js
+++ b/test/unit/discover-suite.js
@@ -284,6 +284,22 @@ define(['bluebird', 'requirejs', 'fs', 'webfinger.js'], function (Promise, requi
             xhr.onreadystatechange();
           };
         }
+      },
+
+      {
+        desc: "if Webfinger request returns a 404 (not found), promise is rejected",
+        run: function (env, test) {
+          RemoteStorage.Discover("foo@bar").then(test.fail, function (err) {
+            test.assertType(err, 'string');
+          });
+          XMLHttpRequest.onOpen = function () {
+            var xhr = XMLHttpRequest.instances[0];
+            xhr.status = 404;
+            xhr.readyState = 4;
+            xhr.responseText = '';
+            xhr.onreadystatechange();
+          };
+        }
       }
     ]
   });

--- a/test/unit/discover-suite.js
+++ b/test/unit/discover-suite.js
@@ -274,7 +274,7 @@ define(['bluebird', 'requirejs', 'fs', 'webfinger.js'], function (Promise, requi
         desc: "if unsuccesfully tried to discover a storage, promise is rejected",
         run: function (env, test) {
           RemoteStorage.Discover("foo@bar").then(test.fail, function (err) {
-            test.assertType(err, 'string');
+            test.assertType(err, 'object');
           });
           XMLHttpRequest.onOpen = function () {
             var xhr = XMLHttpRequest.instances[0];
@@ -290,7 +290,7 @@ define(['bluebird', 'requirejs', 'fs', 'webfinger.js'], function (Promise, requi
         desc: "if Webfinger request returns a 404 (not found), promise is rejected",
         run: function (env, test) {
           RemoteStorage.Discover("foo@bar").then(test.fail, function (err) {
-            test.assertType(err, 'string');
+            test.assertType(err, 'object');
           });
           XMLHttpRequest.onOpen = function () {
             var xhr = XMLHttpRequest.instances[0];

--- a/test/unit/remotestorage-suite.js
+++ b/test/unit/remotestorage-suite.js
@@ -387,7 +387,6 @@ define(['bluebird', 'requirejs', 'tv4'], function (Promise, requirejs, tv4) {
         run: function(env, test) {
           env.rs.on('error', function(e) {
             test.assertAnd(e instanceof RemoteStorage.DiscoveryError, true);
-            test.assertAnd(e.message, "Failed to contact storage server.", "wrong error message : "+e.message);
             test.done();
           });
           env.rs.connect('someone@somewhere');
@@ -400,7 +399,6 @@ define(['bluebird', 'requirejs', 'tv4'], function (Promise, requirejs, tv4) {
           RemoteStorage.config.discoveryTimeout = 500;
           env.rs.on('error', function(e) {
             test.assertAnd(e instanceof RemoteStorage.DiscoveryError, true);
-            test.assertAnd(e.message, "No storage information found at that user address.", "wrong error message : "+e.message);
             test.done();
           });
           env.rs.connect("someone@timeout");


### PR DESCRIPTION
After updating webfinger.js with the version including @silverbucket's fixes for Webfinger 404s not executing any callback functions, I found that no error messages were shown in the widget anymore. Not exactly sure when that broke, but my small refactoring of how they get passed around in the code fixes the problem.

However, in an actual app, I'm seeing weird behaviour when Webfinger fallbacks are being tried (hence the WIP title). There are two different discovery errors being thrown, and the first one claims that it couldn't connect to the storage server, while the second one (a good multiple seconds later), correctly states that it couldn't find storage information on the server. Both are updating the widget, so the first messages is being replaced with the second one after a couple of seconds. Here's what it looks like in my console:

![screenshot from 2016-09-06 13-42-20](https://cloud.githubusercontent.com/assets/842/18274069/8ff5a540-7438-11e6-95f8-8bfbe30864f0.png)

I did see that webfinger.js is throwing multiple errors now, but they were all the same afaics, so it doesn't explain to me why we get two different ones in rs.js. I'll try to find out what's happening exactly and report back.

connected to #937 
fixes #937