### PR TITLE
Add network-offline and network-online events

### DIFF
--- a/src/dropbox.js
+++ b/src/dropbox.js
@@ -847,7 +847,7 @@
     }
   };
 
-  //hooking and unhooking the sync
+  // Hooking and unhooking the sync
 
   function hookSync(rs) {
     if (rs._dropboxOrigSync) { return; } // already hooked
@@ -866,7 +866,7 @@
     delete rs._dropboxOrigSync;
   }
 
-  // hooking and unhooking getItemURL
+  // Hooking and unhooking getItemURL
 
   function hookGetItemURL(rs) {
     if (rs._origBaseClientGetItemURL) { return; }

--- a/src/dropbox.js
+++ b/src/dropbox.js
@@ -611,14 +611,30 @@
      */
     _request: function (method, url, options) {
       var self = this;
+
       if (! options.headers) { options.headers = {}; }
       options.headers['Authorization'] = 'Bearer ' + this.token;
-      return RS.WireClient.request.call(this, method, url, options).then(function (xhr) {
-        //503 means retry this later
+
+      return RS.WireClient.request.call(this, method, url, options).then(function(xhr) {
+        // 503 means retry this later
         if (xhr && xhr.status === 503) {
+          if (self.online) {
+            self.online = false;
+            self.rs._emit('network-offline');
+          }
           return global.setTimeout(self._request(method, url, options), 3210);
         } else {
+          if (!self.online) {
+            self.online = true;
+            self.rs._emit('network-online');
+          }
+
           return Promise.resolve(xhr);
+        }
+      }, function(error) {
+        if (self.online) {
+          self.online = false;
+          self.rs._emit('network-offline');
         }
       });
     },

--- a/src/dropbox.js
+++ b/src/dropbox.js
@@ -636,6 +636,7 @@
           self.online = false;
           self.rs._emit('network-offline');
         }
+        return Promise.reject(error);
       });
     },
 

--- a/src/googledrive.js
+++ b/src/googledrive.js
@@ -394,15 +394,28 @@
 
     _request: function (method, url, options) {
       var self = this;
+
       if (! options.headers) { options.headers = {}; }
       options.headers['Authorization'] = 'Bearer ' + self.token;
-      return RS.WireClient.request(method, url, options).then(function (xhr) {
-        // google tokens expire from time to time...
+
+      return RS.WireClient.request.call(this, method, url, options).then(function(xhr) {
+        // Google tokens expire from time to time...
         if (xhr && xhr.status === 401) {
           self.connect();
           return;
+        } else {
+          if (!self.online) {
+            self.online = true;
+            self.rs._emit('network-online');
+          }
+          return Promise.resolve(xhr);
         }
-        return xhr;
+      }, function(error) {
+        if (self.online) {
+          self.online = false;
+          self.rs._emit('network-offline');
+        }
+        return Promise.reject(error);
       });
     }
   };

--- a/src/remotestorage.js
+++ b/src/remotestorage.js
@@ -167,6 +167,18 @@
      *
      * Fired when a wire request completes
      **/
+    /**
+     * Event: network-offline
+     *
+     * Fired once when a wire request fails for the first time, and
+     * `remote.online` is set to false
+     **/
+    /**
+     * Event: network-online
+     *
+     * Fired once when a wire request succeeds for the first time after a
+     * failed one, and `remote.online` is set back to true
+     **/
 
     // Initial configuration property settings.
     if (typeof cfg === 'object') {

--- a/src/remotestorage.js
+++ b/src/remotestorage.js
@@ -176,8 +176,9 @@
 
     RemoteStorage.eventHandling(
       this, 'ready', 'connected', 'disconnected', 'not-connected', 'conflict',
-            'error', 'features-loaded', 'connecting', 'authing', 'wire-busy',
-            'wire-done', 'sync-interval-change'
+            'error', 'features-loaded', 'connecting', 'authing',
+            'sync-interval-change','wire-busy', 'wire-done',
+            'network-offline', 'network-online'
     );
 
     // pending get/put/delete calls.

--- a/src/remotestorage.js
+++ b/src/remotestorage.js
@@ -189,7 +189,7 @@
     RemoteStorage.eventHandling(
       this, 'ready', 'connected', 'disconnected', 'not-connected', 'conflict',
             'error', 'features-loaded', 'connecting', 'authing',
-            'sync-interval-change','wire-busy', 'wire-done',
+            'sync-interval-change', 'wire-busy', 'wire-done',
             'network-offline', 'network-online'
     );
 

--- a/src/sync.js
+++ b/src/sync.js
@@ -903,7 +903,6 @@
       .then(function (completed) {
         delete self._timeStarted[task.path];
         delete self._running[task.path];
-        self.remote.online = true;
 
         if (completed) {
           if (self._tasks[task.path]) {

--- a/src/sync.js
+++ b/src/sync.js
@@ -872,7 +872,6 @@
           error = new RemoteStorage.Unauthorized();
         } else if (status.networkProblems) {
           error = new RemoteStorage.SyncError('Network request failed.');
-          this.remote.online = false;
         } else {
           error = new Error('HTTP response code ' + status.statusCode + ' received.');
         }

--- a/test/unit/dropbox-suite.js
+++ b/test/unit/dropbox-suite.js
@@ -9,7 +9,7 @@ define(['bluebird', 'requirejs', 'test/behavior/backend', 'test/helpers/mocks'],
 
   function setup(env, test) {
     global.RemoteStorage = function () {
-      RemoteStorage.eventHandling(this, 'error', 'connected');
+      RemoteStorage.eventHandling(this, 'error', 'connected', 'network-offline', 'network-online');
     };
     RemoteStorage.log = function () {};
     RemoteStorage.prototype = {
@@ -720,7 +720,7 @@ define(['bluebird', 'requirejs', 'test/behavior/backend', 'test/helpers/mocks'],
             sync: function() {
               test.assert(fetchDeltaCalled, true);
             }
-          }
+          };
 
           RemoteStorage.Dropbox._rs_init(env.rs);
 

--- a/test/unit/googledrive-suite.js
+++ b/test/unit/googledrive-suite.js
@@ -94,6 +94,11 @@ define(['bluebird', 'requirejs', 'test/behavior/backend', 'test/helpers/mocks'],
 
     mocks.defineMocks(env);
 
+    env.networkOffline = new test.Stub(function(){});
+    env.networkOnline = new test.Stub(function(){});
+    env.rs.on('network-offline', env.networkOffline);
+    env.rs.on('network-online', env.networkOnline);
+
     test.done();
   }
 
@@ -301,6 +306,78 @@ define(['bluebird', 'requirejs', 'test/behavior/backend', 'test/helpers/mocks'],
           setTimeout(function () {
             var req = XMLHttpRequest.instances.shift();
             req.status = 404;
+            req._onload();
+          }, 10);
+        }
+      },
+
+      {
+        desc: "#get with request failure emits network-offline if remote.online was true",
+        run: function(env, test) {
+          env.connectedClient.online = true;
+          env.connectedClient.get('/foo').then(function() {
+          }, function(err) {
+            test.assertAnd(env.networkOffline.numCalled, 1);
+            test.done();
+          });
+          setTimeout(function() {
+            var req = XMLHttpRequest.instances.shift();
+            req._onerror('something went wrong at the XHR level');
+          }, 10);
+        }
+      },
+
+      {
+        desc: "#get with request failure does not emit network-offline if remote.online was false",
+        run: function(env, test) {
+          env.connectedClient.online = false;
+          env.connectedClient.get('/foo').then(function() {
+          }, function(err) {
+            test.assertAnd(env.networkOffline.numCalled, 0);
+            test.done();
+          });
+          setTimeout(function() {
+            var req = XMLHttpRequest.instances.shift();
+            req._onerror('something went wrong at the XHR level');
+          }, 10);
+        }
+      },
+
+      {
+        desc: "#get with success emits network-online if remote.online was false",
+        run: function(env, test) {
+          env.connectedClient.online = false;
+          env.connectedClient._fileIdCache.set('/foo', 'foo_id');
+          env.connectedClient.get('/foo').then(function() {
+            test.assertAnd(env.networkOnline.numCalled, 1);
+            test.done();
+          });
+          setTimeout(function() {
+            var req = XMLHttpRequest.instances.shift();
+            req.status = 200;
+            req.responseText = JSON.stringify({ items: [
+              { etag: '"1234"' }
+            ] });
+            req._onload();
+          }, 10);
+        }
+      },
+
+      {
+        desc: "#get with success does not emit network-online if remote.online was true",
+        run: function(env, test) {
+          env.connectedClient.online = true;
+          env.connectedClient._fileIdCache.set('/foo', 'foo_id');
+          env.connectedClient.get('/foo').then(function() {
+            test.assertAnd(env.networkOnline.numCalled, 0);
+            test.done();
+          });
+          setTimeout(function() {
+            var req = XMLHttpRequest.instances.shift();
+            req.status = 200;
+            req.responseText = JSON.stringify({ items: [
+              { etag: '"1234"' }
+            ] });
             req._onload();
           }, 10);
         }

--- a/test/unit/googledrive-suite.js
+++ b/test/unit/googledrive-suite.js
@@ -10,7 +10,7 @@ define(['bluebird', 'requirejs', 'test/behavior/backend', 'test/helpers/mocks'],
   function setup (env, test) {
     global.localStorage = {};
     global.RemoteStorage = function () {
-      RemoteStorage.eventHandling(this, 'error');
+      RemoteStorage.eventHandling(this, 'error', 'network-offline', 'network-online');
     };
     RemoteStorage.log = function () {};
     RemoteStorage.prototype = {


### PR DESCRIPTION
This adds events for the network going offline (on every failed request) and going back online (on every succeeding successful request). It also moves the setting of remote.online on failure to the right place (same one that success is using).

I'm using this for the new connect widget, but it's also extremely useful for custom widgets/UI and app developers.

refs #923
connected to #923