### PR TITLE
Keep Dropbox client trying to sync when offline

### DIFF
--- a/src/dropbox.js
+++ b/src/dropbox.js
@@ -698,8 +698,8 @@
       }, function (err) {
         this.rs.log('fetchDeltas', err);
         this.rs._emit('error', new RemoteStorage.SyncError('fetchDeltas failed.' + err));
-        promise.reject(err);
-      }).then(function () {
+        return Promise.resolve(args);
+      }.bind(this)).then(function () {
         if (self._revCache) {
           var args = Array.prototype.slice.call(arguments);
           self._revCache._activatePropagation();
@@ -856,6 +856,7 @@
       return this.dropbox.fetchDelta.apply(this.dropbox, arguments).
         then(rs._dropboxOrigSync, function (err) {
           rs._emit('error', new RemoteStorage.SyncError(err));
+          return Promise.reject(err);
         });
     }.bind(rs);
   }


### PR DESCRIPTION
fixes #953 

Took me a while to find the cause, but this fixes the problem of the Dropbox client stopping all sync requests when going offline. When going back online, the sync requests start working again.

In conjunction with #952 it also sends the `network-online` event.

I haven't found a good way to write a test for this yet.

Also, same as [I mentioned for the Google Drive client](https://github.com/remotestorage/remotestorage.js/pull/952#issuecomment-261538725), after coming back online the widget still says "Offline". So far I haven't found the cause for that.