### PR TITLE
Make Travis test on several Node versions

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,9 @@
 language: node_js
 node_js:
-  - 0.10
+  - "0.10"
+  - "0.12"
+  - "6"
+  - "node"
 branches:
   only:
     - master

--- a/test/unit/googledrive-suite.js
+++ b/test/unit/googledrive-suite.js
@@ -383,7 +383,7 @@ define(['bluebird', 'requirejs', 'test/behavior/backend', 'test/helpers/mocks'],
               { etag: '"1234"' }
             ] });
             req._onload();
-          });
+          }, 10);
         }
       },
 
@@ -403,7 +403,7 @@ define(['bluebird', 'requirejs', 'test/behavior/backend', 'test/helpers/mocks'],
               { etag: '"1234"' }
             ] });
             req._onload();
-          });
+          }, 10);
         }
       },
 


### PR DESCRIPTION
This adds versions 0.12.x, latest 6.x and latest node (currently 7.x) to be tested on Travis. Was version 0.10.x only before.