### PR TITLE
Add "name" property to custom error objects

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "version": "1.0.0-alpha1",
   "private": false,
   "license": "MIT",
-  "main": "./release/head/remotestorage.js",
+  "main": "./release/stable/remotestorage.js",
   "repository": {
     "type": "git",
     "url": "git://github.com/remotestorage/remotestorage.js.git"

--- a/src/authorize.js
+++ b/src/authorize.js
@@ -1,6 +1,6 @@
 var log = require('./log');
 var util = require('./util');
-  
+
   function extractParams(url) {
     //FF already decodes the URL fragment in document.location.hash, so use this instead:
     var location = url || Authorize.getLocation().href,
@@ -82,10 +82,14 @@ var util = require('./util');
   };
 
   Authorize.IMPLIED_FAKE_TOKEN = false;
-  
-  Authorize.Unauthorized = function () { Error.apply(this, arguments); };
-  Authorize.Unauthorized.prototype = Object.create(Error.prototype);
 
+  Authorize.Unauthorized = function(message) {
+    this.name = 'Unauthorized';
+    this.message = message;
+    this.stack = (new Error()).stack;
+  };
+  Authorize.Unauthorized.prototype = Object.create(Error.prototype);
+  Authorize.Unauthorized.prototype.constructor = Authorize.Unauthorized;
 
   /**
    * Get current document location

--- a/src/discover.js
+++ b/src/discover.js
@@ -77,14 +77,13 @@ const Discover = function Discover(userAddress) {
   });
 };
 
-
-Discover.DiscoveryError = function (message) {
-  Error.apply(this, arguments);
+Discover.DiscoveryError = function(message) {
+  this.name = 'DiscoveryError';
   this.message = message;
+  this.stack = (new Error()).stack;
 };
-
 Discover.DiscoveryError.prototype = Object.create(Error.prototype);
-
+Discover.DiscoveryError.prototype.constructor = Discover.DiscoveryError;
 
 Discover._rs_init = function (remoteStorage) {
   hasLocalStorage = util.localStorageAvailable();

--- a/src/remotestorage.js
+++ b/src/remotestorage.js
@@ -178,7 +178,6 @@
   RemoteStorage.Unauthorized = Authorize.Unauthorized;
   RemoteStorage.DiscoveryError = Discover.DiscoveryError;
 
- 
   RemoteStorage.prototype = {
     authorize: function authorize(authURL, cordovaRedirectUri) {
       this.access.setStorageType(this.remote.storageType);

--- a/src/sync.js
+++ b/src/sync.js
@@ -1060,17 +1060,15 @@
 
   Sync.SyncError = function(message) {
     this.name = 'SyncError';
-
     var msg = 'Sync failed: ';
     if (typeof(originalError) === 'object' && 'message' in originalError) {
       msg += originalError.message;
       this.stack = originalError.stack;
+      this.originalError = originalError;
     } else {
       msg += originalError;
     }
     this.message = msg;
-
-    this.originalError = originalError;
   };
   Sync.SyncError.prototype = Object.create(Error.prototype);
   Sync.SyncError.prototype.constructor = Sync.SyncError;

--- a/src/sync.js
+++ b/src/sync.js
@@ -4,7 +4,7 @@
   var log = require('./log');
   var Authorize = require('./authorize');
   var config = require('./config');
-  
+
   var isFolder = util.isFolder;
   var isDocument = util.isDocument;
   var equal = util.equal;
@@ -1058,21 +1058,21 @@
     delete remoteStorage.sync;
   };
 
-  
-  var SyncError = function (originalError) {
+  Sync.SyncError = function(message) {
+    this.name = 'SyncError';
+
     var msg = 'Sync failed: ';
     if (typeof(originalError) === 'object' && 'message' in originalError) {
       msg += originalError.message;
+      this.stack = originalError.stack;
     } else {
       msg += originalError;
     }
-    this.originalError = originalError;
     this.message = msg;
+
+    this.originalError = originalError;
   };
-
-  SyncError.prototype = new Error();
-  SyncError.prototype.constructor = SyncError;
-
-  Sync.SyncError = SyncError;
+  Sync.SyncError.prototype = Object.create(Error.prototype);
+  Sync.SyncError.prototype.constructor = Sync.SyncError;
 
   module.exports = Sync;

--- a/src/sync.js
+++ b/src/sync.js
@@ -1058,7 +1058,7 @@
     delete remoteStorage.sync;
   };
 
-  Sync.SyncError = function(message) {
+  Sync.SyncError = function(originalError) {
     this.name = 'SyncError';
     var msg = 'Sync failed: ';
     if (typeof(originalError) === 'object' && 'message' in originalError) {


### PR DESCRIPTION
This adds the property `name` with the error name for our custom errors, so that when handling them one can check for `error.name` instead of `error instanceof Discovery.DiscoveryError` for example. The latter is not possible when importing `RemoteStorage` from the module/package.