### PR TITLE
Fix Google Drive info trying to update the widget

### DIFF
--- a/src/googledrive.js
+++ b/src/googledrive.js
@@ -145,7 +145,6 @@
         } else {
           this.info().then(function(info) {
             this.userAddress = info.user.emailAddress;
-            this.rs.widget.view.setUserAddress(this.userAddress);
             this._emit('connected');
             writeSettingsToCache.apply(this);
           }.bind(this)).catch(function() {

--- a/test/unit/dropbox-suite.js
+++ b/test/unit/dropbox-suite.js
@@ -268,8 +268,6 @@ define(['require', './src/util', './src/dropbox', './src/wireclient', './src/eve
       {
         desc: "#configure fetches the user info when no userAddress is given",
         run: function (env, test) {
-          env.rs.widget = { view: { setUserAddress: function() {} } };
-
           env.client.on('connected', function() {
             test.assert(env.client.userAddress, 'john.doe@example.com');
           });
@@ -365,8 +363,6 @@ define(['require', './src/util', './src/dropbox', './src/wireclient', './src/eve
       {
         desc: "#configure caches token and userAddress in localStorage",
         run: function (env, test) {
-          env.rs.widget = { view: { setUserAddress: function() {} } };
-
           var oldSetItem = global.localStorage.setItem;
           global.localStorage.setItem = function(key, value) {
             test.assertAnd(key, 'remotestorage:dropbox');

--- a/test/unit/googledrive-suite.js
+++ b/test/unit/googledrive-suite.js
@@ -136,8 +136,6 @@ define(['bluebird', 'util', 'require', './src/eventhandling', './src/googledrive
       {
         desc: "#configure fetches the user info when no userAddress is given",
         run: function (env, test) {
-          env.rs.widget = { view: { setUserAddress: function() {} } };
-
           env.client.on('connected', function() {
             test.assert(env.client.userAddress, 'john.doe@gmail.com');
           });
@@ -197,8 +195,6 @@ define(['bluebird', 'util', 'require', './src/eventhandling', './src/googledrive
       {
         desc: "#configure caches token and userAddress in localStorage",
         run: function (env, test) {
-          env.rs.widget = { view: { setUserAddress: function() {} } };
-
           var oldSetItem = global.localStorage.setItem;
           global.localStorage.setItem = function(key, value) {
             test.assertAnd(key, 'remotestorage:googledrive');


### PR DESCRIPTION
Closes remotestorage/remotestorage-widget#13

There is no access to `rs.widget` anymore. The new widget uses the `userAddress` property proactively now.