### PR TITLE
Remove Bluebird dependency from tests

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,7 +14,6 @@
     "babel-core": "^6.18.2",
     "babel-loader": "^6.2.8",
     "babel-preset-es2015": "^6.18.0",
-    "bluebird": "^3.4.6",
     "jaribu": "^2.0.0",
     "uglify-js": "^2.6.1",
     "uuid": "^3.0.1",

--- a/test/unit/baseclient-suite.js
+++ b/test/unit/baseclient-suite.js
@@ -1,8 +1,8 @@
 if (typeof define !== 'function') {
   var define = require('amdefine')(module);
 }
-define(['./src/config', './src/baseclient', 'bluebird', 'test/helpers/mocks', 'tv4'],
-       function (config, BaseClient, Promise, mocks, tv4) {
+define(['./src/config', './src/baseclient', 'test/helpers/mocks', 'tv4'],
+       function (config, BaseClient, mocks, tv4) {
 
   var suites = [];
 

--- a/test/unit/cachinglayer-suite.js
+++ b/test/unit/cachinglayer-suite.js
@@ -1,8 +1,7 @@
 if (typeof(define) !== 'function') {
   var define = require('amdefine')(module);
 }
-define(['require', './src/util', './src/config', './src/inmemorystorage', 'bluebird'], function (require, util, config, InMemoryStorage, Promise) {
-  global.Promise = Promise;
+define(['require', './src/util', './src/config', './src/inmemorystorage'], function (require, util, config, InMemoryStorage) {
   var suites = [];
 
   function stringToArrayBuffer(str) {

--- a/test/unit/discover-suite.js
+++ b/test/unit/discover-suite.js
@@ -1,9 +1,7 @@
 if (typeof define !== 'function') {
   var define = require('amdefine')(module);
 }
-define(['require', 'bluebird', 'fs'],
-       function (require, Promise, fs) {
-
+define(['require', 'fs'], function (require, fs) {
   var suites = [];
 
   suites.push({

--- a/test/unit/dropbox-suite.js
+++ b/test/unit/dropbox-suite.js
@@ -1,10 +1,8 @@
 if (typeof define !== 'function') {
   var define = require('amdefine')(module);
 }
-define(['require', './src/util', './src/dropbox', './src/wireclient', './src/eventhandling', './src/config', 'bluebird', 'test/behavior/backend', 'test/helpers/mocks'],
-       function (require, util, Dropbox, WireClient, eventHandling, config, Promise, backend, mocks) {
-
-  global.Promise = Promise;
+define(['require', './src/util', './src/dropbox', './src/wireclient', './src/eventhandling', './src/config', 'test/behavior/backend', 'test/helpers/mocks'],
+       function (require, util, Dropbox, WireClient, eventHandling, config, backend, mocks) {
 
   var suites = [];
 

--- a/test/unit/googledrive-suite.js
+++ b/test/unit/googledrive-suite.js
@@ -1,10 +1,8 @@
 if (typeof define !== 'function') {
   var define = require('amdefine')(module);
 }
-define(['bluebird', 'util', 'require', './src/eventhandling', './src/googledrive', './src/config', 'test/behavior/backend', 'test/helpers/mocks'],
-       function (Promise, util, require, eventHandling, GoogleDrive, config, backend, mocks) {
-
-  global.Promise = Promise;
+define(['util', 'require', './src/eventhandling', './src/googledrive', './src/config', 'test/behavior/backend', 'test/helpers/mocks'],
+       function (util, require, eventHandling, GoogleDrive, config, backend, mocks) {
 
   var suites = [];
 
@@ -250,9 +248,9 @@ define(['bluebird', 'util', 'require', './src/eventhandling', './src/googledrive
           var req;
           env.connectedClient.get('/foo/bar').then(function () {
             test.result(false, 'get call should not return successful');
-          }, function (err) {
+          }).catch(function (err) {
             test.assertAnd(err, 'request failed or something: undefined');
-          }).finally(function () {
+          }).then(function () {
             test.assertType(req._send, 'object');
           });
           setTimeout(function () {
@@ -268,9 +266,9 @@ define(['bluebird', 'util', 'require', './src/eventhandling', './src/googledrive
           var req;
           env.connectedClient.get('/foo/bar').then(function () {
             test.result(false, 'get call should not return successful');
-          }, function (err) {
+          }).catch(function (err) {
             test.assertAnd(err, 'request failed or something: undefined');
-          }).finally(function () {
+          }).then(function () {
             test.assert(req._headers['Authorization'], 'Bearer ' + env.token);
           });
           setTimeout(function () {
@@ -285,9 +283,9 @@ define(['bluebird', 'util', 'require', './src/eventhandling', './src/googledrive
         run: function (env, test) {
           env.connectedClient.get('/foo/bar').then(function () {
             test.result(false, 'get call should not return successful');
-          }, function (err) {
+          }).catch(function (err) {
             test.assertAnd(err, 'request failed or something: undefined');
-          }).finally(function () {
+          }).then(function () {
             test.done();
           });
           setTimeout(function () {

--- a/test/unit/indexeddb-suite.js
+++ b/test/unit/indexeddb-suite.js
@@ -1,8 +1,7 @@
 if (typeof(define) !== 'function') {
   var define = require('amdefine')(module);
 }
-define(['bluebird', './src/indexeddb', './src/config'], function (Promise, IndexedDB, config) {
-
+define(['./src/indexeddb', './src/config'], function (IndexedDB, config) {
   var suites = [];
 
   suites.push({

--- a/test/unit/inmemorycaching-suite.js
+++ b/test/unit/inmemorycaching-suite.js
@@ -1,9 +1,7 @@
 if (typeof(define) !== 'function') {
   var define = require('amdefine')(module);
 }
-define(['bluebird', './src/config', './src/inmemorystorage'], function (Promise, config, InMemoryStorage) {
-  global.Promise = Promise;
-
+define(['./src/config', './src/inmemorystorage'], function (config, InMemoryStorage) {
   var suites = [];
 
   suites.push({

--- a/test/unit/localstorage-suite.js
+++ b/test/unit/localstorage-suite.js
@@ -1,8 +1,7 @@
 if (typeof(define) !== 'function') {
   var define = require('amdefine')(module);
 }
-define(['bluebird', './src/config', './src/localstorage'], function (Promise, config, LocalStorage) {
-
+define(['./src/config', './src/localstorage'], function (config, LocalStorage) {
   var suites = [];
 
   var NODES_PREFIX = 'remotestorage:cache:nodes:';

--- a/test/unit/modules-suite.js
+++ b/test/unit/modules-suite.js
@@ -1,8 +1,7 @@
 if (typeof(define) !== 'function') {
   var define = require('amdefine');
 }
-define(['./src/remotestorage', './src/modules', 'bluebird'], function(RemoteStorage, modules, Promise) {
-
+define(['./src/remotestorage', './src/modules'], function(RemoteStorage, modules) {
   var suites = [];
 
   suites.push({

--- a/test/unit/remotestorage-suite.js
+++ b/test/unit/remotestorage-suite.js
@@ -1,15 +1,11 @@
 if (typeof(define) !== 'function') {
   var define = require('amdefine.js');
 }
-define(['bluebird', 'require', 'tv4', './src/eventhandling'],
-       function (Promise, require, tv4, eventHandling) {
-
+define(['require', 'tv4', './src/eventhandling'], function (require, tv4, eventHandling) {
   var suites = [];
 
   var consoleLog, fakeLogs;
-  global.Promise = Promise;
   global.XMLHttpRequest = require('xhr2').XMLHttpRequest;
-  // global.eventHandling = require('./src/eventhandling');
 
   function FakeRemote(connected) {
     this.fakeRemote = true;

--- a/test/unit/sync-suite.js
+++ b/test/unit/sync-suite.js
@@ -2,10 +2,7 @@ if (typeof(define) !== 'function') {
   var define = require('amdefine');
 }
 
-define(['bluebird', 'require', 'test/helpers/mocks'],
-       function(Promise, require, mocks) {
-  global.Promise = Promise;
-
+define(['require', 'test/helpers/mocks'], function(require, mocks) {
   var suites = [];
 
   function flatten(array){
@@ -27,7 +24,7 @@ define(['bluebird', 'require', 'test/helpers/mocks'],
       global.RemoteStorage = function(){
         eventHandling(this, 'sync-busy', 'sync-done', 'ready', 'connected', 'sync-interval-change', 'error');
       };
-       global.RemoteStorage.log = function() {};
+      global.RemoteStorage.log = function() {};
       global.Authorize = require('./src/authorize');
       global.config = require('./src/config');
       global.eventHandling = require('./src/eventhandling');

--- a/test/unit/util-suite.js
+++ b/test/unit/util-suite.js
@@ -1,8 +1,7 @@
 if (typeof(define) !== 'function') {
   var define = require('amdefine')(module);
 }
-define(['bluebird', './src/util'], function (Promise, util) {
-  global.Promise = Promise;
+define(['./src/util'], function (util) {
   var suites = [];
 
   function stringToArrayBuffer(str) {

--- a/test/unit/versioning-suite.js
+++ b/test/unit/versioning-suite.js
@@ -2,9 +2,9 @@ if (typeof(define) !== 'function') {
   var define = require('amdefine');
 }
 
-define(['./src/config', './src/eventhandling', './src/inmemorystorage', './src/sync', 'bluebird', 'require', 'test/helpers/mocks'],
-       function (config, eventHandling, InMemoryStorage, Sync, Promise, require, mocks) {
-  global.Promise = Promise;
+define(['./src/config', './src/eventhandling', './src/inmemorystorage', './src/sync', 'require', 'test/helpers/mocks'],
+       function (config, eventHandling, InMemoryStorage, Sync, require, mocks) {
+
   var suites = [];
 
   function flatten(array){

--- a/test/unit/wireclient-suite.js
+++ b/test/unit/wireclient-suite.js
@@ -1,9 +1,9 @@
 if (typeof define !== 'function') {
   var define = require('amdefine')(module);
 }
-define(['bluebird', './src/sync', './src/wireclient', './src/authorize', './src/eventhandling', './src/config', 'test/behavior/backend', 'test/helpers/mocks'],
-       function(Promise, Sync, WireClient, Authorize, eventHandling, config, backend, mocks, undefined) {
-  global.Promise = Promise;
+define(['./src/sync', './src/wireclient', './src/authorize', './src/eventhandling', './src/config', 'test/behavior/backend', 'test/helpers/mocks'],
+       function(Sync, WireClient, Authorize, eventHandling, config, backend, mocks, undefined) {
+
   var suites = [];
 
   function setup(env, test) {


### PR DESCRIPTION
This PR removes the remaining dependencies on Bluebird from the tests. Now we can completely remove it from our `devDependencies`.