### PR TITLE
Stop all sync requests after disconnect

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,10 @@ All releases can also be found and downloaded on the
 
 * Switch Dropbox adapter to use the Dropbox API v2 (#936)
 
+### Bugfixes
+
+* Remove all scheduled sync calls after disconnect (#994)
+
 ## 0.14.0 (November 2016)
 
 ### Enhancements

--- a/src/remotestorage.js
+++ b/src/remotestorage.js
@@ -710,6 +710,7 @@
         if (!this.sync.stopped) {
           if (this._syncTimer) {
             clearTimeout(this._syncTimer);
+            this._syncTimer = undefined;
           }
           this._syncTimer = setTimeout(this.sync.sync.bind(this.sync), this.getCurrentSyncInterval());
         }
@@ -719,6 +720,9 @@
     },
 
     stopSync: function () {
+      clearTimeout(this._syncTimer);
+      this._syncTimer = undefined;
+
       if (this.sync) {
         log('[Sync] Stopping sync');
         this.sync.stopped = true;

--- a/test/unit/remotestorage-suite.js
+++ b/test/unit/remotestorage-suite.js
@@ -497,6 +497,26 @@ define(['require', 'tv4', './src/eventhandling'], function (require, tv4, eventH
           env.rs.setRequestTimeout(30000);
           test.assert(env.rs.getRequestTimeout(), 30000);
         }
+      },
+
+      {
+        desc: "#stopSync clears any scheduled sync calls",
+        run: function (env, test) {
+          // This timeout should not be called because it gets cancelled by stopSync()
+          env.rs._syncTimer = setTimeout(function() {
+            test.result(false, "This should not have been called after stopSync");
+          }, 10);
+
+          // This timeout ends the test successfully when the previous timeout
+          // doesn't get called
+          setTimeout(function() {
+            test.result(true);
+          }, 20);
+
+          env.rs.stopSync();
+
+          test.assertAnd(env.rs._syncTimer, undefined);
+        }
       }
     ]
   });


### PR DESCRIPTION
Fixes #994

This stops all scheduled sync requests after disconnecting.

During testing I noticed that for remoteStorage and Google Drive backends it would also still do one `sync()` call after disconnecting, but that one would not do a request for a directory listing like for the Dropbox backend. So this change might indeed also fix #939 as @skddc suspected, but I'm not sure about this.