### PR TITLE
Remove change event from remote clients

### DIFF
--- a/src/dropbox.js
+++ b/src/dropbox.js
@@ -191,7 +191,7 @@
       }
     };
 
-    eventHandling(this, 'change', 'connected', 'wire-busy', 'wire-done', 'not-connected');
+    eventHandling(this, 'connected', 'wire-busy', 'wire-done', 'not-connected');
     rs.on('error', onErrorCb);
 
     this.clientId = rs.apiKeys.dropbox.appKey;

--- a/src/googledrive.js
+++ b/src/googledrive.js
@@ -88,7 +88,7 @@
 
   var GoogleDrive = function (remoteStorage, clientId) {
 
-    eventHandling(this, 'change', 'connected', 'wire-busy', 'wire-done', 'not-connected');
+    eventHandling(this, 'connected', 'wire-busy', 'wire-done', 'not-connected');
 
     this.rs = remoteStorage;
     this.clientId = clientId;

--- a/src/wireclient.js
+++ b/src/wireclient.js
@@ -188,16 +188,11 @@
     this.connected = false;
 
     /**
-     * Event: change
-     *   Never fired for some reason
-     *   # TODO create issue and fix or remove
-     *
      * Event: connected
      *   Fired when the wireclient connect method realizes that it is in
      *   possession of a token and href
      **/
-    eventHandling(this, 'change', 'connected', 'not-connected',
-                           'wire-busy', 'wire-done');
+    eventHandling(this, 'connected', 'not-connected', 'wire-busy', 'wire-done');
 
     onErrorCb = function (error){
       if (error instanceof Authorize.Unauthorized) {


### PR DESCRIPTION
Fixes #1007

The remote clients are not emitting the change event, that's handled by the baseclient instead.