### PR TITLE
Remove step that is not required anymore

### DIFF
--- a/doc/contributing/release-checklist.rst
+++ b/doc/contributing/release-checklist.rst
@@ -10,7 +10,6 @@ Release Checklist
     * Collect and summarize changes using `git log <LAST RELEASE TAG>..HEAD`
     * Add changes to `CHANGELOG.md`
 
-* If new files were added to `test/unit/`, then add them to `.travis.yml`
 * Verify tests are green: `npm test`
 * Bump version in `src/version.js`
 * Bump version in `package.json`


### PR DESCRIPTION
Travis is using the Makefile now (as of e68d3c45), so no need to update
the `.travis.yml` file when adding new test files