### PR TITLE
Improve usage of setApiKeys

### DIFF
--- a/doc/js-api/remotestorage.rst
+++ b/doc/js-api/remotestorage.rst
@@ -150,8 +150,10 @@ The following functions can be called on your ``remoteStorage`` instance:
 
   .. code:: javascript
 
-     remoteStorage.setApiKeys('dropbox', { appKey: 'your-app-key' });
-     remoteStorage.setApiKeys('googledrive', { clientId: 'your-client-id' });}
+     remoteStorage.setApiKeys({
+       dropbox: 'your-app-key',
+       googledrive: 'your-client-id'
+     });
 
 .. autofunction:: RemoteStorage#setCordovaRedirectUri
   :short-name:

--- a/src/googledrive.js
+++ b/src/googledrive.js
@@ -116,7 +116,7 @@ Cache.prototype = {
 };
 
 const GoogleDrive = function (remoteStorage, clientId) {
-  
+
   eventHandling(this, 'connected', 'wire-busy', 'wire-done', 'not-connected');
 
   this.rs = remoteStorage;

--- a/src/remotestorage.js
+++ b/src/remotestorage.js
@@ -124,7 +124,7 @@ var RemoteStorage = function (cfg) {
   }.bind(this);
 
   this.on('ready', this.fireInitial.bind(this));
-  this.loadModules()
+  this.loadModules();
 };
 
 // FIXME: Instead of doing this, would be better to only

--- a/test/unit/remotestorage-suite.js
+++ b/test/unit/remotestorage-suite.js
@@ -179,7 +179,7 @@ define(['require', 'tv4', './src/eventhandling'], function (require, tv4, eventH
         run: function(env, test) {
           Dropbox._rs_init = test.done;
 
-          env.rs.setApiKeys('dropbox', { appKey: 'testkey' });
+          env.rs.setApiKeys({ dropbox: 'testkey' });
         }
       },
 
@@ -192,7 +192,7 @@ define(['require', 'tv4', './src/eventhandling'], function (require, tv4, eventH
 
           Dropbox._rs_init = test.done;
 
-          env.rs.setApiKeys('dropbox', { appKey: 'new key' });
+          env.rs.setApiKeys({ dropbox: 'new key' });
         }
       },
 
@@ -207,8 +207,45 @@ define(['require', 'tv4', './src/eventhandling'], function (require, tv4, eventH
               test.fail('Backend got reinitialized again although the key did not change.');
             };
 
-          env.rs.setApiKeys('dropbox', { appKey: 'old key' });
+          env.rs.setApiKeys({ dropbox: 'old key' });
           test.done();
+        }
+      },
+
+      {
+        desc: "#setApiKeys allows setting values for 'googledrive' and 'dropbox'",
+        run: function(env, test) {
+          env.rs.setApiKeys({
+            dropbox: '123abc',
+            googledrive: '456def'
+          });
+
+          test.assert(env.rs.apiKeys['dropbox'].appKey, '123abc');
+          test.assert(env.rs.apiKeys['googledrive'].clientId, '456def');
+          test.assert(env.rs.dropbox.clientId, '123abc');
+          test.assert(env.rs.googledrive.clientId, '456def');
+        }
+      },
+
+      {
+        desc: "#setApiKeys returns false when receiving invalid config",
+        run: function(env, test) {
+          test.assert(env.rs.setApiKeys({ icloud: '123abc' }), false);
+        }
+      },
+
+      {
+        desc: "#setApiKeys clears config when receiving null values",
+        run: function(env, test) {
+          env.rs.setApiKeys({
+            dropbox: null,
+            googledrive: null
+          });
+
+          test.assertType(env.rs.apiKeys['dropbox'], 'undefined');
+          test.assertType(env.rs.apiKeys['googledrive'], 'undefined');
+          test.assert(env.rs.dropbox.clientId, 'null');
+          test.assert(env.rs.googledrive.clientId, 'null');
         }
       },
 


### PR DESCRIPTION
Currently, one needs to call the same function twice in order to set api keys for both Dropbox and Google Drive. This changes the signature to accept (and require) a config object with backend type as keys and api keys as properties.  It also removes the need to pass in specific key objects with `appKey` and `clientId` properties.