### PR TITLE
Transpile Array.includes

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -274,6 +274,12 @@
         "babel-runtime": "6.25.0"
       }
     },
+    "babel-plugin-array-includes": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/babel-plugin-array-includes/-/babel-plugin-array-includes-2.0.3.tgz",
+      "integrity": "sha1-z1RS6Bx7gD+3lZ8QRayI4uwo/3Y=",
+      "dev": true
+    },
     "babel-plugin-check-es2015-constants": {
       "version": "https://registry.npmjs.org/babel-plugin-check-es2015-constants/-/babel-plugin-check-es2015-constants-6.22.0.tgz",
       "integrity": "sha1-NRV7EBQm/S/9PaP3XH0ekYNbv4o=",

--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
   "devDependencies": {
     "babel-core": "^6.18.2",
     "babel-loader": "^6.2.8",
+    "babel-plugin-array-includes": "^2.0.3",
     "babel-preset-es2015": "^6.18.0",
     "jaribu": "^2.0.0",
     "uglify-js": "^2.6.1",

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -35,9 +35,9 @@ module.exports = {
         exclude: /node_modules/,
         loader: 'babel-loader',
         query: {
-          presets: ['es2015']
+          presets: ['es2015'],
+          plugins: ['babel-plugin-array-includes']
         }
-
       }
     ]
   }


### PR DESCRIPTION
`includes` is not available in e.g. IE 11.