### PR TITLE
Remove explicit UglifyJS dependency

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2208,17 +2208,6 @@
         "is-typedarray": "1.0.0"
       }
     },
-    "uglify-js": {
-      "version": "2.8.29",
-      "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-2.8.29.tgz",
-      "integrity": "sha1-KcVzMUgFe7Th913zW3qcty5qWd0=",
-      "dev": true,
-      "requires": {
-        "source-map": "https://registry.npmjs.org/source-map/-/source-map-0.5.6.tgz",
-        "uglify-to-browserify": "https://registry.npmjs.org/uglify-to-browserify/-/uglify-to-browserify-1.0.2.tgz",
-        "yargs": "https://registry.npmjs.org/yargs/-/yargs-3.10.0.tgz"
-      }
-    },
     "uglify-to-browserify": {
       "version": "https://registry.npmjs.org/uglify-to-browserify/-/uglify-to-browserify-1.0.2.tgz",
       "integrity": "sha1-bgkk1r2mta/jSeOabWMoUKD4grc=",

--- a/package.json
+++ b/package.json
@@ -25,7 +25,6 @@
     "babel-plugin-array-includes": "^2.0.3",
     "babel-preset-es2015": "^6.18.0",
     "jaribu": "^2.0.0",
-    "uglify-js": "^2.6.1",
     "uuid": "^3.0.1",
     "webpack": "^1.13.2"
   },


### PR DESCRIPTION
Webpack brings its own uglify, so we don't need to manage it ourselves anymore. The currently linked version is outdated anyway, so this also fixes the David DM warning.