### PR TITLE
Remove obsolete variable declaration

### DIFF
--- a/src/dropbox.js
+++ b/src/dropbox.js
@@ -163,7 +163,6 @@
     this.rs = rs;
     this.connected = false;
     this.rs = rs;
-    var self = this;
 
     eventHandling(this, 'connected', 'wire-busy', 'wire-done', 'not-connected');
 

--- a/src/types.js
+++ b/src/types.js
@@ -1,5 +1,3 @@
-var tv4 = require('tv4');
-
 /**
  * @class BaseClient.Types
  *


### PR DESCRIPTION
UglifyJS removed this `self` (with a warning), because it's unused.