### PR TITLE
Document the RemoteStorage constructor's config argument

### DIFF
--- a/doc/js-api/base-client.rst
+++ b/doc/js-api/base-client.rst
@@ -261,7 +261,9 @@ Events with origin ``conflict`` are fired when a conflict occurs while pushing
 out your local changes to the remote store.
 
 Say you changed 'color.txt' from 'white' to 'blue'; if you have set
-``config.changeEvents.window`` to ``true``, then you will receive:
+``config.changeEvents.window`` to ``true`` (by passing it to the
+``RemoteStorage`` constructor, see the Constructor section of the
+:doc:`RemoteStorage API doc </js-api/remotestorage>`), then you will receive:
 
 .. code:: javascript
 

--- a/doc/js-api/remotestorage.rst
+++ b/doc/js-api/remotestorage.rst
@@ -15,15 +15,21 @@ The constructor can optionally be called with a configuration object, for
 example::
 
    var remoteStorage = new RemoteStorage({
+     // enable caching, defaults to true
      cache: true,
+     // Change Events that are enabled, default to true except for window
+     // which is false
      changeEvents: {
        local:    true,
        window:   false,
        remote:   true,
        conflict: true
      },
+     // set a redirect URI for Cordova apps, defaults to undefined
      cordovaRedirectUri: undefined,
+     // enable remoteStorage logging, defaults to false
      logging: false,
+     // extra remoteStorage data modules to load, defaults to an empty list
      modules: []
    });
 

--- a/doc/js-api/remotestorage.rst
+++ b/doc/js-api/remotestorage.rst
@@ -16,6 +16,43 @@ example::
      cordovaRedirectUri: 'https://app.wow-much-app.com' // defaults to undefined
    });
 
+Here is a complete list of the default options (set in ``src/config/js``), all
+of which can be overridden by calling the constructor with a configuration
+object like above::
+
+   {
+     // Enable remoteStorage logging
+     logging: false,
+     // Change Events that are enabled. See the BaseClient API for more information
+     changeEvents: {
+       local:    true,
+       window:   false,
+       remote:   true,
+       conflict: true
+     },
+     // enable caching
+     cache: true,
+     // disable specified modules
+     disableFeatures: [],
+     // timeout for the Webfinger lookup, discovering a connecting user's storage details
+     discoveryTimeout: 10000,
+     // sync interval when the application is in the foreground
+     syncInterval: 10000,
+     // sync interval when the application is in the background
+     backgroundSyncInterval: 60000,
+     // initial value for the internal state of the app being in the background
+     isBackground: false,
+     // set a redirect URI for Cordova apps
+     cordovaRedirectUri: undefined,
+     // timeout for network requests
+     requestTimeout: 30000,
+     // extra ES6 modules to load
+     modules: []
+   };
+
+For more information about the Change Events, see
+:doc:`the BaseClient API doc</js-api/base-client>`.
+
 .. NOTE::
    In the current version, it is only possible to use a single
    ``RemoteStorage`` instance. You cannot connect to two different remotes yet.

--- a/doc/js-api/remotestorage.rst
+++ b/doc/js-api/remotestorage.rst
@@ -23,7 +23,6 @@ example::
        conflict: true
      },
      cordovaRedirectUri: undefined,
-     disableFeatures: [],
      logging: false,
      modules: []
    });

--- a/doc/js-api/remotestorage.rst
+++ b/doc/js-api/remotestorage.rst
@@ -4,6 +4,9 @@ RemoteStorage
 Constructor
 -----------
 
+.. autofunction:: RemoteStorage([config])
+  :short-name:
+
 Create a ``remoteStorage`` instance like so::
 
    var remoteStorage = new RemoteStorage();
@@ -12,46 +15,18 @@ The constructor can optionally be called with a configuration object, for
 example::
 
    var remoteStorage = new RemoteStorage({
-     logging: true,  // defaults to false
-     cordovaRedirectUri: 'https://app.wow-much-app.com' // defaults to undefined
-   });
-
-Here is a complete list of the default options (set in ``src/config/js``), all
-of which can be overridden by calling the constructor with a configuration
-object like above::
-
-   {
-     // Enable remoteStorage logging
-     logging: false,
-     // Change Events that are enabled. See the BaseClient API for more information
+     cache: true,
      changeEvents: {
        local:    true,
        window:   false,
        remote:   true,
        conflict: true
      },
-     // enable caching
-     cache: true,
-     // disable specified modules
-     disableFeatures: [],
-     // timeout for the Webfinger lookup, discovering a connecting user's storage details
-     discoveryTimeout: 10000,
-     // sync interval when the application is in the foreground
-     syncInterval: 10000,
-     // sync interval when the application is in the background
-     backgroundSyncInterval: 60000,
-     // initial value for the internal state of the app being in the background
-     isBackground: false,
-     // set a redirect URI for Cordova apps
      cordovaRedirectUri: undefined,
-     // timeout for network requests
-     requestTimeout: 30000,
-     // extra ES6 modules to load
+     disableFeatures: [],
+     logging: false,
      modules: []
-   };
-
-For more information about the Change Events, see
-:doc:`the BaseClient API doc</js-api/base-client>`.
+   });
 
 .. NOTE::
    In the current version, it is only possible to use a single

--- a/src/config.js
+++ b/src/config.js
@@ -3,33 +3,24 @@
  * RemoteStorage object
  */
 var config = {
-  // Enable remoteStorage logging
-  logging: false,
-  // Change Events that are enabled. See the BaseClient API for more information
+  cache: true,
   changeEvents: {
     local:    true,
     window:   false,
     remote:   true,
     conflict: true
   },
-  // enable caching
-  cache: true,
-  // disable specified modules
-  disableFeatures: [],
-  // timeout for the Webfinger lookup, discovering a connecting user's storage details
-  discoveryTimeout: 10000,
-  // sync interval when the application is in the foreground
-  syncInterval: 10000,
-  // sync interval when the application is in the background
-  backgroundSyncInterval: 60000,
-  // initial value for the internal state of the app being in the background
-  isBackground: false,
-  // set a redirect URI for Cordova apps
   cordovaRedirectUri: undefined,
-  // timeout for network requests
+  disableFeatures: [],
+  logging: false,
+  modules: [],
+  // the following are not public and will probably be moved away from the
+  // default config
+  backgroundSyncInterval: 60000,
+  discoveryTimeout: 10000,
+  isBackground: false,
   requestTimeout: 30000,
-  // extra ES6 modules to load
-  modules: []
+  syncInterval: 10000
 };
 
 module.exports = config;

--- a/src/config.js
+++ b/src/config.js
@@ -11,12 +11,12 @@ var config = {
     conflict: true
   },
   cordovaRedirectUri: undefined,
-  disableFeatures: [],
   logging: false,
   modules: [],
   // the following are not public and will probably be moved away from the
   // default config
   backgroundSyncInterval: 60000,
+  disableFeatures: [],
   discoveryTimeout: 10000,
   isBackground: false,
   requestTimeout: 30000,

--- a/src/config.js
+++ b/src/config.js
@@ -1,19 +1,34 @@
+/**
+ * The default config, merged with the object passed to the constructor of the
+ * RemoteStorage object
+ */
 var config = {
+  // Enable remoteStorage logging
   logging: false,
+  // Change Events that are enabled. See the BaseClient API for more information
   changeEvents: {
     local:    true,
     window:   false,
     remote:   true,
     conflict: true
   },
+  // enable caching
   cache: true,
+  // disable specified modules
   disableFeatures: [],
+  // timeout for the Webfinger lookup, discovering a connecting user's storage details
   discoveryTimeout: 10000,
+  // sync interval when the application is in the foreground
   syncInterval: 10000,
+  // sync interval when the application is in the background
   backgroundSyncInterval: 60000,
+  // initial value for the internal state of the app being in the background
   isBackground: false,
+  // set a redirect URI for Cordova apps
   cordovaRedirectUri: undefined,
+  // timeout for network requests
   requestTimeout: 30000,
+  // extra ES6 modules to load
   modules: []
 };
 

--- a/src/discover.js
+++ b/src/discover.js
@@ -17,9 +17,6 @@ var cachedInfo = {};
  * This function deals with the Webfinger lookup, discovering a connecting
  * user's storage details.
  *
- * The discovery timeout can be configured via
- * `config.discoveryTimeout` (in ms).
- *
  * @param {string} userAddress - user@host
  *
  * @returns {Promise} A promise for an object with the following properties.

--- a/src/features.js
+++ b/src/features.js
@@ -26,7 +26,7 @@ const Features = {
       'Env': require('./env')
     };
 
-    // enable caching releate module if needed
+    // enable caching related modules if needed
     if (config.cache) {
       util.extend( this.featureModules, {
         'Caching': require('./caching'),
@@ -37,7 +37,9 @@ const Features = {
       });
     }
 
-    // disable specified modules
+    // disable features set in the config object passed to the RemoteStorage
+    // constructor
+    // For example: ['IndexedDB']
     config.disableFeatures.forEach( feature => {
       if (this.featureModules[feature]) {
         // this.featureModules[feature] = undefined

--- a/src/remotestorage.js
+++ b/src/remotestorage.js
@@ -39,7 +39,6 @@ function emitUnauthorized(r) {
  * @param {boolean} config.changeEvents.remote - defaults to true
  * @param {boolean} config.changeEvents.conflict - defaults to true
  * @param {string} config.cordovaRedirectUri - set a redirect URI for Cordova apps
- * @param {array} config.disableFeatures - disable specified features
  * @param {boolean} config.logging - enable remoteStorage logging, defaults to false
  * @param {array} config.modules - extra remoteStorage data modules to load
  * @class

--- a/src/remotestorage.js
+++ b/src/remotestorage.js
@@ -32,15 +32,6 @@ function emitUnauthorized(r) {
  * and functions. See the individual features for more information.
  *
  * @param {object} config - an optional configuration object
- * @param {boolean} config.cache - enable caching, defaults to true
- * @param {object} config.changeEvents - Change Events that are enabled. See the :doc:`the BaseClient API doc</js-api/base-client>` for more information
- * @param {boolean} config.changeEvents.local - defaults to true
- * @param {boolean} config.changeEvents.window - defaults to false
- * @param {boolean} config.changeEvents.remote - defaults to true
- * @param {boolean} config.changeEvents.conflict - defaults to true
- * @param {string} config.cordovaRedirectUri - set a redirect URI for Cordova apps
- * @param {boolean} config.logging - enable remoteStorage logging, defaults to false
- * @param {array} config.modules - extra remoteStorage data modules to load
  * @class
  */
 var RemoteStorage = function (cfg) {

--- a/src/remotestorage.js
+++ b/src/remotestorage.js
@@ -30,6 +30,19 @@ function emitUnauthorized(r) {
  *
  * Depending on which features are built in, it contains different attributes
  * and functions. See the individual features for more information.
+ *
+ * @param {object} config - an optional configuration object
+ * @param {boolean} config.cache - enable caching, defaults to true
+ * @param {object} config.changeEvents - Change Events that are enabled. See the :doc:`the BaseClient API doc</js-api/base-client>` for more information
+ * @param {boolean} config.changeEvents.local - defaults to true
+ * @param {boolean} config.changeEvents.window - defaults to false
+ * @param {boolean} config.changeEvents.remote - defaults to true
+ * @param {boolean} config.changeEvents.conflict - defaults to true
+ * @param {string} config.cordovaRedirectUri - set a redirect URI for Cordova apps
+ * @param {array} config.disableFeatures - disable specified features
+ * @param {boolean} config.logging - enable remoteStorage logging, defaults to false
+ * @param {array} config.modules - extra remoteStorage data modules to load
+ * @class
  */
 var RemoteStorage = function (cfg) {
 


### PR DESCRIPTION
I'm not sure what the best format for this is, so far I used comments above each value and duplicated it in `src/config.js` as well.

https://github.com/erikrose/sphinx-js says this about abusing autofunction to document @typedef tags, but I found this to be confusing when I tried it, especially since our `config` is just a variable.

> There is experimental support for abusing autofunction to document @typedef tags as well, though the result will be styled as a function, and @property tags will fall misleadingly under an "Arguments" heading. Still, it's better than nothing until we can do it properly.

What do you think?

Connected to #1033