### PR TITLE
Sync interval docs

### DIFF
--- a/doc/js-api/remotestorage.rst
+++ b/doc/js-api/remotestorage.rst
@@ -86,6 +86,10 @@ List of events
    Emitted once when a wire request succeeds for the first time after a failed
    one, and ``remote.online`` is set back to true
 
+``sync-interval-change``
+"""""""""
+   Emitted when the sync interval changes
+
 Prototype functions
 -------------------
 

--- a/doc/js-api/remotestorage.rst
+++ b/doc/js-api/remotestorage.rst
@@ -87,7 +87,7 @@ List of events
    one, and ``remote.online`` is set back to true
 
 ``sync-interval-change``
-"""""""""
+""""""""""""""""""""""""
    Emitted when the sync interval changes
 
 Prototype functions

--- a/src/remotestorage.js
+++ b/src/remotestorage.js
@@ -608,7 +608,7 @@ RemoteStorage.prototype = {
   /**
    * Set the value of the sync interval when application is in the foreground
    *
-   * @param {number} interval - Sync interval in milliseconds
+   * @param {number} interval - Sync interval in milliseconds (between 1000 and 3600000)
    */
   setSyncInterval: function (interval) {
     if (!isValidInterval(interval)) {
@@ -632,7 +632,7 @@ RemoteStorage.prototype = {
    * Set the value of the sync interval when the application is in the
    * background
    *
-   * @param interval - Sync interval in milliseconds
+   * @param interval - Sync interval in milliseconds (between 1000 and 3600000)
    */
   setBackgroundSyncInterval: function (interval) {
     if(!isValidInterval(interval)) {


### PR DESCRIPTION
I have reviewed the code examples from the new JS API docs (`RemoteStorage` class).

I have added a missing event as well as documentation about the allowed range of the sync interval.

I don't think I'm the right person to document `RemoteStorage#authorize()`, who has used this function before?

What do we want to do about the `enableLog` and `disableLog` functions? https://remotestoragejs.readthedocs.io/en/latest/js-api/remotestorage.html#enableLog