### PR TITLE
Fix Dropbox binary uploads

### DIFF
--- a/index.js
+++ b/index.js
@@ -2,9 +2,4 @@ global.XMLHttpRequest = require('xhr2');
 
 const RemoteStorage = require('./src/remotestorage.js');
 
-// TODO re-introduce fix (or verify it's obsolete)
-// RemoteStorage.WireClient.readBinaryData = function (content, mimeType, callback) {
-//   callback(content);
-// };
-
 module.exports = RemoteStorage;

--- a/index.js
+++ b/index.js
@@ -2,4 +2,9 @@ global.XMLHttpRequest = require('xhr2');
 
 const RemoteStorage = require('./src/remotestorage.js');
 
+// TODO re-introduce fix (or verify it's obsolete)
+// RemoteStorage.WireClient.readBinaryData = function (content, mimeType, callback) {
+//   callback(content);
+// };
+
 module.exports = RemoteStorage;

--- a/src/dropbox.js
+++ b/src/dropbox.js
@@ -432,11 +432,16 @@
 
         // handling binary
         if (!mime || mime.match(/charset=binary/)) {
-          return Promise.resolve({
-            statusCode: status,
-            body: resp.response,
-            contentType: mime,
-            revision: rev
+          // FIXME: would be better to make readBinaryData return a Promise - les
+          return new Promise( (resolve, reject) => {
+            WireClient.readBinaryData(resp.response, mime, function (result) {
+              resolve({
+                statusCode: status,
+                body: result,
+                contentType: mime,
+                revision: rev
+              });
+            });
           });
         }
 

--- a/src/dropbox.js
+++ b/src/dropbox.js
@@ -432,16 +432,11 @@
 
         // handling binary
         if (!mime || mime.match(/charset=binary/)) {
-          // FIXME: would be better to make readBinaryData return a Promise - les
-          return new Promise( (resolve, reject) => {
-            WireClient.readBinaryData(resp.response, mime, function (result) {
-              resolve({
-                statusCode: status,
-                body: result,
-                contentType: mime,
-                revision: rev
-              });
-            });
+          return Promise.resolve({
+            statusCode: status,
+            body: resp.response,
+            contentType: mime,
+            revision: rev
           });
         }
 

--- a/src/dropbox.js
+++ b/src/dropbox.js
@@ -91,7 +91,7 @@
      *
      * @protected
      */
-    get : function (key) {
+    get: function (key) {
       key = key.toLowerCase();
       var stored = this._storage[key];
       if (typeof stored === 'undefined'){
@@ -104,7 +104,7 @@
     /**
      * Set a value and also update the parent folders with that value.
      */
-    propagateSet : function (key, value) {
+    propagateSet: function (key, value) {
       key = key.toLowerCase();
       if (this._storage[key] === value) {
         return value;
@@ -117,7 +117,7 @@
     /**
      * Delete a value and propagate the changes to the parent folders.
      */
-    propagateDelete : function (key) {
+    propagateDelete: function (key) {
       key = key.toLowerCase();
       this._propagate(key, this._storage[key]);
       return delete this._storage[key];
@@ -132,7 +132,7 @@
     /**
      * Set a value without propagating.
      */
-    justSet : function (key, value) {
+    justSet: function (key, value) {
       key = key.toLowerCase();
       this._storage[key] = value;
       return value;
@@ -141,7 +141,7 @@
     /**
      * Delete a value without propagating.
      */
-    justDelete : function (key, value) {
+    justDelete: function (key, value) {
       key = key.toLowerCase();
       return delete this._storage[key];
     },

--- a/src/dropbox.js
+++ b/src/dropbox.js
@@ -61,6 +61,10 @@
     return new RegExp('^' + expect.join('\\/') + '(\\/|$)').test(response.error_summary);
   };
 
+  const isBinaryData = function (data) {
+    return data instanceof ArrayBuffer || WireClient.isArrayBufferView(data);
+  }
+
   /**
    * A cache which automatically converts all keys to lower case and can
    * propagate changes up to parent folders.
@@ -487,8 +491,7 @@
         return Promise.resolve({statusCode: 412, revision: savedRev});
       }
 
-      if ((!contentType.match(/charset=/)) &&
-          (body instanceof ArrayBuffer || WireClient.isArrayBufferView(body))) {
+      if ((!contentType.match(/charset=/)) && isBinaryData(body)) {
         contentType += '; charset=binary';
       }
 
@@ -678,7 +681,7 @@
       }
       options.headers['Authorization'] = 'Bearer ' + this.token;
 
-      if (typeof options.body === 'object') {
+      if (typeof options.body === 'object' && !isBinaryData(options.body)) {
         options.body = JSON.stringify(options.body);
         options.headers['Content-Type'] = 'application/json; charset=UTF-8';
       }

--- a/src/wireclient.js
+++ b/src/wireclient.js
@@ -97,30 +97,6 @@
     return str.replace(/^["']|["']$/g, '');
   }
 
-  function readBinaryData(content, mimeType, callback) {
-    var blob;
-    util.globalContext.BlobBuilder = util.globalContext.BlobBuilder || util.globalContext.WebKitBlobBuilder;
-    if (typeof util.globalContext.BlobBuilder !== 'undefined') {
-      var bb = new global.BlobBuilder();
-      bb.append(content);
-      blob = bb.getBlob(mimeType);
-    } else {
-      blob = new Blob([content], { type: mimeType });
-    }
-
-    var reader = new FileReader();
-    if (typeof reader.addEventListener === 'function') {
-      reader.addEventListener('loadend', function () {
-        callback(reader.result); // reader.result contains the contents of blob as a typed array
-      });
-    } else {
-      reader.onloadend = function() {
-        callback(reader.result); // reader.result contains the contents of blob as a typed array
-      };
-    }
-    reader.readAsArrayBuffer(blob);
-  }
-
   function getTextFromArrayBuffer(arrayBuffer, encoding) {
     return new Promise((resolve, reject) => {
       if (typeof Blob === 'undefined') {
@@ -499,8 +475,6 @@
 
   // Shared isArrayBufferView used by WireClient and Dropbox
   WireClient.isArrayBufferView = isArrayBufferView;
-
-  WireClient.readBinaryData = readBinaryData;
 
   // Shared request function used by WireClient, GoogleDrive and Dropbox.
   // TODO: Should we use fetch ?

--- a/src/wireclient.js
+++ b/src/wireclient.js
@@ -97,6 +97,30 @@
     return str.replace(/^["']|["']$/g, '');
   }
 
+  function readBinaryData(content, mimeType, callback) {
+    var blob;
+    util.globalContext.BlobBuilder = util.globalContext.BlobBuilder || util.globalContext.WebKitBlobBuilder;
+    if (typeof util.globalContext.BlobBuilder !== 'undefined') {
+      var bb = new global.BlobBuilder();
+      bb.append(content);
+      blob = bb.getBlob(mimeType);
+    } else {
+      blob = new Blob([content], { type: mimeType });
+    }
+
+    var reader = new FileReader();
+    if (typeof reader.addEventListener === 'function') {
+      reader.addEventListener('loadend', function () {
+        callback(reader.result); // reader.result contains the contents of blob as a typed array
+      });
+    } else {
+      reader.onloadend = function() {
+        callback(reader.result); // reader.result contains the contents of blob as a typed array
+      };
+    }
+    reader.readAsArrayBuffer(blob);
+  }
+
   function getTextFromArrayBuffer(arrayBuffer, encoding) {
     return new Promise((resolve, reject) => {
       if (typeof Blob === 'undefined') {
@@ -475,6 +499,8 @@
 
   // Shared isArrayBufferView used by WireClient and Dropbox
   WireClient.isArrayBufferView = isArrayBufferView;
+
+  WireClient.readBinaryData = readBinaryData;
 
   // Shared request function used by WireClient, GoogleDrive and Dropbox.
   // TODO: Should we use fetch ?

--- a/test/unit/dropbox-suite.js
+++ b/test/unit/dropbox-suite.js
@@ -33,12 +33,6 @@ define(['require', './src/util', './src/dropbox', './src/wireclient', './src/eve
   }
 
   function beforeEach(env, test) {
-    global.ArrayBufferMock = function(str) {
-      return {
-        iAmA: 'ArrayBufferMock',
-        content: str
-      };
-    };
     global.XMLHttpRequest = function () {
       XMLHttpRequest.instances.push(this);
       this._headers = {};
@@ -819,25 +813,28 @@ define(['require', './src/util', './src/dropbox', './src/wireclient', './src/eve
       },
 
       {
-        desc: "responses with the charset set to 'binary' are left as the raw response",
+        desc: "responses with the charset set to 'binary' are read using a FileReader, after constructing a Blob",
         run: function (env, test) {
           env.connectedClient.get('/foo/bar').
             then(function (r) {
-              test.assertAnd(r.statusCode, 200);
-              test.assertAnd(r.body, {
-                iAmA: 'ArrayBufferMock',
-                content: 'response-body'
+              // check Blob
+              test.assertTypeAnd(env.blob, 'object');
+              test.assertAnd(env.blob.input, ['response-body']);
+              test.assertAnd(env.blob.options, {
+                type: 'application/octet-stream; charset=binary'
               });
+
+              test.assertAnd(r.statusCode, 200);
+              test.assertAnd(r.body, env.fileReaderResult);
               test.assert(r.contentType, 'application/octet-stream; charset=binary');
             });
-
           var req = XMLHttpRequest.instances.shift();
           req._responseHeaders['Content-Type'] = 'application/octet-stream; charset=binary';
           req._responseHeaders['Dropbox-API-Result'] = JSON.stringify({
             rev: 'rev'
           });
           req.status = 200;
-          req.response = new ArrayBufferMock('response-body');
+          req.response = 'response-body';
           req._onload();
         }
       },
@@ -848,7 +845,7 @@ define(['require', './src/util', './src/dropbox', './src/wireclient', './src/eve
           env.connectedClient.get('/foo/bar').
             then(function (r) {
               test.assertAnd(r.statusCode, 200);
-              test.assertAnd(r.body, 'response-body');
+              test.assertAnd(r.body, env.fileReaderResult);
               test.done();
             });
           var req = XMLHttpRequest.instances.shift();


### PR DESCRIPTION
Fixes #1048 

This fixes Dropbox converting binary data to JSON.

It also removes the use of `WireClient.readBinaryData`, which has been obsolete for quite a while now.