### PR TITLE
Add missing revision on successful put to Dropbox

### DIFF
--- a/src/dropbox.js
+++ b/src/dropbox.js
@@ -915,7 +915,8 @@
         }
 
         this._revCache.propagateSet(params.path, body.rev);
-        return Promise.resolve({ statusCode: response.status });
+
+        return Promise.resolve({ statusCode: response.status, revision: body.rev });
       });
     },
 

--- a/test/unit/dropbox-suite.js
+++ b/test/unit/dropbox-suite.js
@@ -717,6 +717,25 @@ define(['require', './src/util', './src/dropbox', './src/wireclient', './src/eve
       },
 
       {
+        desc: "#put responds with the revision of the file when successful",
+        run: function (env, test) {
+          env.connectedClient.put('/foo/bar', 'data', 'text/plain').
+            then(function (r) {
+              test.assert(r.revision, 'some-revision');
+            });
+          setTimeout(function () {
+            var req = XMLHttpRequest.instances.shift();
+            req.status = 200;
+            req.responseText = JSON.stringify({
+              path: '/remotestorage/foo/bar',
+              rev: 'some-revision'
+            });
+            req._onload();
+          }, 100);
+        }
+      },
+
+      {
         desc: "#put returns the erroneous status it received from DropBox",
         run: function (env, test) {
           env.connectedClient.put('/foo', 'data', 'text/plain').


### PR DESCRIPTION
Fixes #1042

This fixes the problem, that remote files would not be deleted when they were created in the same session. 