### PR TITLE
Fix delayed event handler registration

### DIFF
--- a/doc/js-api/remotestorage.rst
+++ b/doc/js-api/remotestorage.rst
@@ -44,6 +44,8 @@ You can handle events from your ``remoteStorage`` instance by using the
      // Storage account has been connected, let’s roll!
    });
 
+.. _rs-events:
+
 List of events
 ^^^^^^^^^^^^^^
 
@@ -239,6 +241,21 @@ The following functions can be called on your ``remoteStorage`` instance:
   Example::
 
      remoteStorage.stopSync();
+
+.. function:: on(eventName, handler)
+
+  Register an event handler. See :ref:`rs-events` for available event names.
+
+  :param eventName: Name of the event
+  :param handler: Event handler
+  :type eventName: string
+  :type handler: function
+
+  Example::
+
+     remoteStorage.on('connected', function() {
+       console.log('user connected their storage');
+     });
 
 .. autofunction:: RemoteStorage#onChange(path, handler)
   :short-name:

--- a/doc/js-api/remotestorage.rst
+++ b/doc/js-api/remotestorage.rst
@@ -242,14 +242,8 @@ The following functions can be called on your ``remoteStorage`` instance:
 
      remoteStorage.stopSync();
 
-.. function:: on(eventName, handler)
-
-  Register an event handler. See :ref:`rs-events` for available event names.
-
-  :param eventName: Name of the event
-  :param handler: Event handler
-  :type eventName: string
-  :type handler: function
+.. autofunction:: RemoteStorage#on(eventName, handler)
+  :short-name:
 
   Example::
 

--- a/src/remotestorage.js
+++ b/src/remotestorage.js
@@ -106,11 +106,31 @@ var RemoteStorage = function (cfg) {
    * @private
    */
   this.on = function (eventName, handler) {
-    if (eventName === 'ready' && this.remote && this.remote.connected && this._allLoaded) {
-      setTimeout(handler, 0);
-    } else if (eventName === 'features-loaded' && this._allLoaded) {
-      setTimeout(handler, 0);
+    // check if the handler should be called immedtiately, because the
+    // event has happened already
+    switch(eventName) {
+      case 'features-loaded':
+        if (this._allLoaded) {
+          setTimeout(handler, 0);
+        }
+        break;
+      case 'ready':
+        if (this._allLoaded && this.remote) {
+          setTimeout(handler, 0);
+        }
+        break;
+      case 'connected':
+        if (this._allLoaded && this.remote && this.remote.connected) {
+          setTimeout(handler, 0);
+        }
+        break;
+      case 'not-connected':
+        if (this._allLoaded && this.remote && !this.remote.connected) {
+          setTimeout(handler, 0);
+        }
+        break;
     }
+
     return origOn.call(this, eventName, handler);
   };
 

--- a/src/remotestorage.js
+++ b/src/remotestorage.js
@@ -110,27 +110,27 @@ var RemoteStorage = function (cfg) {
   this.on = function (eventName, handler) {
     // check if the handler should be called immedtiately, because the
     // event has happened already
-    switch(eventName) {
-      case 'features-loaded':
-        if (this._allLoaded) {
+    if (this._allLoaded) {
+      switch(eventName) {
+        case 'features-loaded':
           setTimeout(handler, 0);
-        }
-        break;
-      case 'ready':
-        if (this._allLoaded && this.remote) {
-          setTimeout(handler, 0);
-        }
-        break;
-      case 'connected':
-        if (this._allLoaded && this.remote && this.remote.connected) {
-          setTimeout(handler, 0);
-        }
-        break;
-      case 'not-connected':
-        if (this._allLoaded && this.remote && !this.remote.connected) {
-          setTimeout(handler, 0);
-        }
-        break;
+          break;
+        case 'ready':
+          if (this.remote) {
+            setTimeout(handler, 0);
+          }
+          break;
+        case 'connected':
+          if (this.remote && this.remote.connected) {
+            setTimeout(handler, 0);
+          }
+          break;
+        case 'not-connected':
+          if (this.remote && !this.remote.connected) {
+            setTimeout(handler, 0);
+          }
+          break;
+      }
     }
 
     return origOn.call(this, eventName, handler);

--- a/src/remotestorage.js
+++ b/src/remotestorage.js
@@ -108,9 +108,9 @@ var RemoteStorage = function (cfg) {
    * @param {function} handler - Event handler
    */
   this.on = function (eventName, handler) {
-    // check if the handler should be called immedtiately, because the
-    // event has happened already
     if (this._allLoaded) {
+      // check if the handler should be called immediately, because the
+      // event has happened already
       switch(eventName) {
         case 'features-loaded':
           setTimeout(handler, 0);

--- a/src/remotestorage.js
+++ b/src/remotestorage.js
@@ -387,8 +387,8 @@ RemoteStorage.prototype = {
    * You should usually not use this method directly, but instead use the
    * "change" events provided by :doc:`BaseClient </js-api/base-client>`
    *
-   * @param path    - Absolute path to attach handler to
-   * @param handler - Handler function
+   * @param {string} path - Absolute path to attach handler to
+   * @param {function} handler - Handler function
    */
   onChange: function (path, handler) {
     if (! this._pathHandlers.change[path]) {

--- a/src/remotestorage.js
+++ b/src/remotestorage.js
@@ -98,12 +98,14 @@ var RemoteStorage = function (cfg) {
     this.setBackend(localStorage.getItem('remotestorage:backend') || 'remotestorage');
   }
 
+  // Keep a reference to the orginal `on` function
   var origOn = this.on;
 
   /**
-   * TODO: document
+   * Register an event handler. See :ref:`rs-events` for available event names.
    *
-   * @private
+   * @param {string} eventName - Name of the event
+   * @param {function} handler - Event handler
    */
   this.on = function (eventName, handler) {
     // check if the handler should be called immedtiately, because the


### PR DESCRIPTION
This should fix the issue reported in remotestorage/remotestorage-widget#56.

When registering event handlers after the events already fired, they would not be triggered.
In the widget issue [I commented](https://github.com/remotestorage/remotestorage-widget/issues/56#issuecomment-338649163) that although the `connected` event handler would not be triggered, at least the `ready` event would always get triggered. But that was actually not the case. It was only triggered, when the user was connected.

I fixed this so the `ready` is always triggered. And I also added checks for `connected` and `not-connected`, so they also get triggered when registering a handler after those events were originally fired already.

I also added documentation for the `on` function. I had to document the function in the `remotestorage.rst` document directly, because the function is created in the constructor and Sphinx wouldn't find the function and the associated JSDoc.