### PR TITLE
Fix link (missing leading slash)

### DIFF
--- a/doc/data-modules/defining-a-module.rst
+++ b/doc/data-modules/defining-a-module.rst
@@ -19,7 +19,7 @@ defining the properties and functions to be used in the app as ``exports``:
      }
    }};
 
-You can then load it into your :doc:`RemoteStorage <js-api/remotestorage>`
+You can then load it into your :doc:`RemoteStorage </js-api/remotestorage>`
 instance either on initialization, or later using the ``addModule()`` function::
 
    const remoteStorage = new RemoteStorage({ modules: [ Bookmarks ] });


### PR DESCRIPTION
I found this missing leading slash in a link, couldn't find other issues. Ready to merge