### PR TITLE
Fix binary detection for Dropbox and Google Drive

### DIFF
--- a/src/util.js
+++ b/src/util.js
@@ -410,6 +410,52 @@
       } catch(error) {
         return false;
       }
+    },
+
+    /**
+     * Decide if data should be treated as binary based on the content
+     * and content-type.
+     *
+     * @param {string} content - The data
+     * @param {string} mimeType - The data's content-type
+     *
+     * @returns {boolean}
+     */
+    shouldBeTreatedAsBinary (content, mimeType) {
+      return !mimeType || mimeType.match(/charset=binary/) || /[\x00-\x1F]/.test(content);
+    },
+
+    /**
+     * Read binary data and return it as ArrayBuffer.
+     *
+     * @param {string} content - The data
+     * @param {string} mimeType - The data's content-type
+     * @returns {Promise} Resolves with an ArrayBuffer containing the data
+     */
+     readBinaryData (content, mimeType) {
+      return new Promise((resolve) => {
+        let blob;
+        util.globalContext.BlobBuilder = util.globalContext.BlobBuilder || util.globalContext.WebKitBlobBuilder;
+        if (typeof util.globalContext.BlobBuilder !== 'undefined') {
+          const bb = new global.BlobBuilder();
+          bb.append(content);
+          blob = bb.getBlob(mimeType);
+        } else {
+          blob = new Blob([content], { type: mimeType });
+        }
+
+        const reader = new FileReader();
+        if (typeof reader.addEventListener === 'function') {
+          reader.addEventListener('loadend', function () {
+            resolve(reader.result); // reader.result contains the contents of blob as a typed array
+          });
+        } else {
+          reader.onloadend = function() {
+            resolve(reader.result); // reader.result contains the contents of blob as a typed array
+          };
+        }
+        reader.readAsArrayBuffer(blob);
+      });
     }
 
   };

--- a/src/util.js
+++ b/src/util.js
@@ -422,7 +422,7 @@
      * @returns {boolean}
      */
     shouldBeTreatedAsBinary (content, mimeType) {
-      return !mimeType || mimeType.match(/charset=binary/) || /[\x00-\x1F]/.test(content);
+      return (mimeType && mimeType.match(/charset=binary/)) || /[\x00-\x1F]/.test(content);
     },
 
     /**

--- a/src/wireclient.js
+++ b/src/wireclient.js
@@ -77,6 +77,7 @@
 
   const isFolder = util.isFolder;
   const cleanPath = util.cleanPath;
+  const shouldBeTreatedAsBinary = util.shouldBeTreatedAsBinary;
 
   function addQuotes(str) {
     if (typeof(str) !== 'string') {
@@ -282,7 +283,7 @@
 
           var charset = determineCharset(mimeType);
 
-          if ((!mimeType) || charset === 'binary') {
+          if (shouldBeTreatedAsBinary(response.response, mimeType)) {
             log('[WireClient] Successful request with unknown or binary mime-type', revision);
             return Promise.resolve({statusCode: response.status, body: response.response, contentType: mimeType, revision: revision});
           } else {


### PR DESCRIPTION
Fixes #1059

With this fix, downloaded binary data is returned as ArrayBuffer, similar to binaries from a remoteStorage backend.