### PR TITLE
Fix disconnect in Safari

### DIFF
--- a/src/indexeddb.js
+++ b/src/indexeddb.js
@@ -441,8 +441,9 @@ IndexedDB._rs_cleanup = function (remoteStorage) {
       remoteStorage.local.closeDB();
     }
 
-    IndexedDB.clean(DEFAULT_DB_NAME, resolve);
+    IndexedDB.clean(DEFAULT_DB_NAME, function () {}); // use empty callback, because we don't want to wait
 
+    resolve();
   });
 };
 

--- a/src/indexeddb.js
+++ b/src/indexeddb.js
@@ -319,6 +319,7 @@ IndexedDB.open = function (name, callback) {
       var db = req.result;
       if(!db.objectStoreNames.contains('nodes') || !db.objectStoreNames.contains('changes')) {
         log("[IndexedDB] Missing object store. Resetting the database.");
+        db.close();
         IndexedDB.clean(name, function() {
           IndexedDB.open(name, callback);
         });


### PR DESCRIPTION
Fixes #1086 

This doesn't wait for the IndexedDB to be deleted before resolving the `_rs_cleanup()` promise, so the disconnected event gets fired in Safari.