### PR TITLE
Fix Dropbox throwing an error on failed requests

### DIFF
--- a/src/dropbox.js
+++ b/src/dropbox.js
@@ -796,6 +796,13 @@ Dropbox.prototype = {
         if (responseBody.has_more) {
           return fetch(responseBody.cursor);
         }
+      }).catch((error) => {
+        if (error instanceof ProgressEvent) {
+          // Offline is handled elsewhere already, just ignore it here
+          return Promise.resolve();
+        } else {
+          return Promise.reject(error);
+        }
       });
     };
 


### PR DESCRIPTION
As reported in remotestorage/remotestorage-widget#69, the Dropbox client throws an error when offline.

This catches the error and just ignores it, because the offline handling (e.g. emitting the appropriate events) is already handled.