### PR TITLE
Link to remotestorage.io from docs

### DIFF
--- a/doc/index.rst
+++ b/doc/index.rst
@@ -9,8 +9,10 @@ remoteStorage.js
 Welcome to the remoteStorage.js documentation!
 
 remoteStorage.js is a JavaScript library for storing user data locally in the
-browser, as well as connecting to user-owned storage accounts and syncing data
-across devices and applications.
+browser, as well as connecting to [remoteStorage](http://remotestorage.io)
+servers and syncing data across devices and applications. It is also capable of
+connecting and syncing data with a person's Dropbox or Google Drive account
+(optional).
 
 .. NOTE::
   For brevity's sake, we will also use the short name rs.js across these docs.


### PR DESCRIPTION
I had the experience of ending up on the doc page while I was actually trying to go to the main website and I couldn't find any link.
Would be good to add some reference. The phrasing can be changed though.