### PR TITLE
Don't close IndexedDB DB while still writing to it

### DIFF
--- a/src/indexeddb.js
+++ b/src/indexeddb.js
@@ -274,7 +274,11 @@ IndexedDB.prototype = {
   },
 
   closeDB: function () {
-    this.db.close();
+    if (this.putsRunning === 0) { // check if we are currently writing to the DB
+      this.db.close();
+    } else {
+      setTimeout(this.closeDB.bind(this), 100); // try again a little later
+    }
   }
 
 };

--- a/test/unit/indexeddb-suite.js
+++ b/test/unit/indexeddb-suite.js
@@ -140,8 +140,34 @@ define(['./src/indexeddb', './src/config'], function (IndexedDB, config) {
           test.assertAnd(env.idb.changesQueued, {});
           test.assertAnd(env.idb.changesRunning, {foo: {path: 'foo'}});
         }
-      }
-/* TODO: mock indexeddb with some nodejs library
+      },
+
+      {
+        desc: "closeDB waits for already running writes to finish",
+        run: function(env, test) {
+          let originalClose = env.idb.db.close;
+
+          env.idb.putsRunning = 1;
+
+          env.idb.db.close = function () {
+            if (env.idb.putsRunning > 0) {
+              test.result(false, 'DB was closed while there are still puts running');
+            } else {
+              test.result(true);
+            }
+
+            env.idb.db.close = originalClose;
+          };
+
+          env.idb.closeDB();
+
+          setTimeout(function () {
+            env.idb.putsRunning = 0;
+          }, 150);
+        }
+      },
+
+      /* TODO: mock indexeddb with some nodejs library
       {
         desc: "getNodes, setNodes",
         run: function(env, test) {


### PR DESCRIPTION
Waits for the writes to finish first before closing the DB.

Fixes #939