### PR TITLE
Fix remote.storageApi not being set correctly

### DIFF
--- a/src/discover.js
+++ b/src/discover.js
@@ -21,7 +21,7 @@ var cachedInfo = {};
  *
  * @returns {Promise} A promise for an object with the following properties.
  *          href - Storage base URL,
- *          storageType - Storage type,
+ *          storageApi - RS protocol version,
  *          authUrl - OAuth URL,
  *          properties - Webfinger link properties
  **/
@@ -52,11 +52,16 @@ const Discover = function Discover(userAddress) {
       var rs = response.idx.links.remotestorage[0];
       var authURL = rs.properties['http://tools.ietf.org/html/rfc6749#section-4.2'] ||
                     rs.properties['auth-endpoint'];
-      var storageType = rs.properties['http://remotestorage.io/spec/version'] ||
-                        rs.type;
+      var storageApi = rs.properties['http://remotestorage.io/spec/version'] ||
+                       rs.type;
 
       // cache fetched data
-      cachedInfo[userAddress] = { href: rs.href, storageType: storageType, authURL: authURL, properties: rs.properties };
+      cachedInfo[userAddress] = {
+        href: rs.href,
+        storageApi: storageApi,
+        authURL: authURL,
+        properties: rs.properties
+      };
 
       if (hasLocalStorage) {
         localStorage[SETTINGS_KEY] = JSON.stringify({ cache: cachedInfo });

--- a/src/remotestorage.js
+++ b/src/remotestorage.js
@@ -178,7 +178,7 @@ RemoteStorage.prototype = {
    * @param {string} cordovaRedirectUri
    */
   authorize: function authorize(authURL, cordovaRedirectUri) {
-    this.access.setStorageType(this.remote.storageType);
+    this.access.setStorageType(this.remote.storageApi);
     var scope = this.access.scopeParameter;
 
     var redirectUri = globalContext.cordova ? cordovaRedirectUri : String(Authorize.getLocation());

--- a/test/unit/discover-suite.js
+++ b/test/unit/discover-suite.js
@@ -104,7 +104,7 @@ define(['require', 'fs'], function (require, fs) {
           Discover('nil@heahdk.net').then(function (info) {
             test.assertAnd(info, {
               href: 'https://base/url',
-              storageType: 'draft-dejong-remotestorage-01',
+              storageApi: 'draft-dejong-remotestorage-01',
               authURL: 'https://auth/url',
               properties: {
                 'http://tools.ietf.org/html/rfc6749#section-4.2': 'https://auth/url'
@@ -140,7 +140,7 @@ define(['require', 'fs'], function (require, fs) {
           Discover('me@localhost:8001').then(function (info) {
             test.assertAnd(info, {
               href: 'https://base/url',
-              storageType: 'draft-dejong-remotestorage-01',
+              storageApi: 'draft-dejong-remotestorage-01',
               authURL: 'https://auth/url',
               properties: {
                 'http://tools.ietf.org/html/rfc6749#section-4.2': 'https://auth/url'
@@ -164,7 +164,7 @@ define(['require', 'fs'], function (require, fs) {
           Discover('nil1@heahdk.net').then(function (info) {
             test.assertAnd(info, {
               href: 'https://base/url',
-              storageType: 'draft-dejong-remotestorage-05',
+              storageApi: 'draft-dejong-remotestorage-05',
               authURL: 'https://auth/url',
               properties: {
                 'http://remotestorage.io/spec/version': 'draft-dejong-remotestorage-05',
@@ -203,7 +203,7 @@ define(['require', 'fs'], function (require, fs) {
           Discover('nil2@heahdk.net').then(function (info) {
             test.assertAnd(info, {
               href: 'https://base/url',
-              storageType: 'draft-dejong-remotestorage-02',
+              storageApi: 'draft-dejong-remotestorage-02',
               authURL: 'https://auth/url',
               properties: {
                 'http://remotestorage.io/spec/version': 'draft-dejong-remotestorage-02',
@@ -242,7 +242,7 @@ define(['require', 'fs'], function (require, fs) {
           Discover('nil2@heahdk.net').then(function (info) {
             test.assertAnd(info, {
               href: 'https://base/url',
-              storageType: 'draft-dejong-remotestorage-02',
+              storageApi: 'draft-dejong-remotestorage-02',
               authURL: 'https://auth/url',
               properties: {
                 'http://remotestorage.io/spec/version': 'draft-dejong-remotestorage-02',


### PR DESCRIPTION
Some places that should be using storageApi are setting storageType instead. But the latter is a different property, albeit related in functionality.

This fixes a serious problem with versioning, which is that due to storageApi not being set in the remote/wireclient, no `If-Match` headers are sent in PUT requests.

fixes #1120