### PR TITLE
Set output.globalObject option in Webpack config

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -22,7 +22,8 @@ module.exports = {
     // global export name if needed
     library: 'RemoteStorage',
     libraryTarget: 'umd',
-    umdNamedDefine: true
+    umdNamedDefine: true,
+    globalObject: 'this'
   },
   // the only external dependecy is xmlhttprequest because it is
   // different in browser and in node env so user has to manage with that


### PR DESCRIPTION
Fixes #1126

This fixes a reference error when using the build in a WebWorker.

This is a workaround taken from https://github.com/webpack/webpack/issues/6642#issuecomment-371087342 and should be replaced by `target: "universal"` when https://github.com/webpack/webpack/issues/6525 has been implemented.