### PR TITLE
Make Dropbox correctly fetch folders

### DIFF
--- a/src/dropbox.js
+++ b/src/dropbox.js
@@ -375,6 +375,11 @@ Dropbox.prototype = {
     var url = 'https://content.dropboxapi.com/2/files/download';
     var self = this;
 
+    //use _getFolder for folders
+    if (path.substr(-1) === '/') {
+      return this._getFolder(path, options);
+    }
+
     var savedRev = this._revCache.get(path);
     if (savedRev === null) {
       // file was deleted server side
@@ -384,11 +389,6 @@ Dropbox.prototype = {
        savedRev && (savedRev === options.ifNoneMatch)) {
       // nothing changed.
       return Promise.resolve({statusCode: 304});
-    }
-
-    //use _getFolder for folders
-    if (path.substr(-1) === '/') {
-      return this._getFolder(path, options);
     }
 
     var params = {

--- a/test/unit/dropbox-suite.js
+++ b/test/unit/dropbox-suite.js
@@ -624,6 +624,38 @@ define(['require', './src/util', './src/dropbox', './src/wireclient',
         },
 
         {
+          desc: "#get correctly recognizes changes in folders",
+          run: function (env, test) {
+            env.connectedClient.get('/').then(function (r) {
+              env.connectedClient.get('/', { ifNoneMatch: r.revision }).then(function (r) {
+                test.assertFail(r.statusCode, 304);
+              });
+              var req = XMLHttpRequest.instances.shift();
+              test.assertFail(req, undefined);
+              req.status = 200;
+              req.responseText = JSON.stringify({
+                entries: [{
+                  '.tag': 'file',
+                  path_lower: 'foo',
+                  rev: '2'
+                }]
+              });
+              req._onload();
+            });
+            var req = XMLHttpRequest.instances.shift();
+            req.status = 200;
+            req.responseText = JSON.stringify({
+              entries: [{
+                '.tag': 'file',
+                path_lower: 'foo',
+                rev: '1'
+              }]
+            });
+            req._onload();
+          }
+        },
+
+        {
           desc: "#put causes the revision to propagate down in revCache",
           run: function (env, test) {
             env.connectedClient._revCache.set('/foo/', 'foo');


### PR DESCRIPTION
This fixes #1128.

I have spent quite some time to figure this out and I still can't quite put all of it to words, but the problem seems to be the following:

When rs.js drops with the Dropbox backend, it first gets a recursive listing of everything under the storage prefix (`/remotestorage` for me). This is used to fill/update the revision cache.

Then the usual task collection begins and (in the example from the issue) determines that `/` should be refreshed, let's say. This is delegated to `Dropbox#get`, which is given the current revision of `/` (which is just `"rev"`, the default value of the revision cache, because `/` is a folder). The "preflight" listing mentioned above again wrote `rev` to the revision cache for the path `/` and so the `get` function immediately determines there is nothing to do and returns a status of 304 (nothing changed).

This might not be true, though. The backend **has** to check the folder listing for `/` again, to see whether any of its items changed. `_getFolder` does this correctly, so I just reordered the "early 304" and the delegation to `_getFolder`.

I am not sure whether this is the "morally correct" solution, so any input is very much appreciated. :smile: 