### PR TITLE
fix GoogleDrive and Dropbox getFile returning corrupted binary data

### DIFF
--- a/src/dropbox.js
+++ b/src/dropbox.js
@@ -45,8 +45,8 @@ const PATH_PREFIX = '/remotestorage';
 const isFolder = util.isFolder;
 const cleanPath = util.cleanPath;
 const shouldBeTreatedAsBinary = util.shouldBeTreatedAsBinary;
-const readBinaryData = util.readBinaryData;
 const getJSONFromLocalStorage = util.getJSONFromLocalStorage;
+const getTextFromArrayBuffer = util.getTextFromArrayBuffer;
 
 /**
  * Map a local path to a path in Dropbox.
@@ -389,8 +389,9 @@ Dropbox.prototype = {
 
     var params = {
       headers: {
-        'Dropbox-API-Arg': JSON.stringify({path: getDropboxPath(path)})
-      }
+        'Dropbox-API-Arg': JSON.stringify({path: getDropboxPath(path)}),
+      },
+      responseType: 'arraybuffer'
     };
     if (options && options.ifNoneMatch) {
       params.headers['If-None-Match'] = options.ifNoneMatch;
@@ -403,51 +404,53 @@ Dropbox.prototype = {
         return Promise.resolve({statusCode: status});
       }
       meta = resp.getResponseHeader('Dropbox-API-Result');
-      body = resp.responseText;
+      //first encode the response as text, and later check if 
+      //text appears to actually be binary data
+      return getTextFromArrayBuffer(resp.response, 'UTF-8')
+        .then(function (responseText) {
+          body = responseText;
+            if (status === 409) {
+              meta = body;
+            }
 
-      if (status === 409) {
-        meta = body;
-      }
+            try {
+              meta = JSON.parse(meta);
+            } catch(e) {
+              return Promise.reject(e);
+            }
 
-      try {
-        meta = JSON.parse(meta);
-      } catch(e) {
-        return Promise.reject(e);
-      }
+            if (status === 409) {
+              if (compareApiError(meta, ['path', 'not_found'])) {
+                return {statusCode: 404};
+              }
+              return Promise.reject(new Error('API error while downloading file ("' + path + '"): ' + meta.error_summary));
+            }
 
-      if (status === 409) {
-        if (compareApiError(meta, ['path', 'not_found'])) {
-          return Promise.resolve({statusCode: 404});
-        }
-        return Promise.reject(new Error('API error while downloading file ("' + path + '"): ' + meta.error_summary));
-      }
+            mime = resp.getResponseHeader('Content-Type');
+            rev = meta.rev;
+            self._revCache.set(path, rev);
+            self._shareIfNeeded(path);
 
-      mime = resp.getResponseHeader('Content-Type');
-      rev = meta.rev;
-      self._revCache.set(path, rev);
-      self._shareIfNeeded(path);
+            if (shouldBeTreatedAsBinary(responseText, mime)) {
+              //return unprocessed response 
+              body = resp.response;
+            } else {
+              // handling json (always try)
+              try {
+                body = JSON.parse(body);
+                mime = 'application/json; charset=UTF-8';
+              } catch(e) {
+                //Failed parsing Json, assume it is something else then
+              }
+            }
 
-      // handling binary
-      if (shouldBeTreatedAsBinary(resp.response, mime)) {
-        return readBinaryData(resp.response, mime).then((result) => {
-          return {
-            statusCode: status,
-            body: result,
-            contentType: mime,
-            revision: rev
-          };
-        });
-      }
-
-      // handling json (always try)
-      try {
-        body = JSON.parse(body);
-        mime = 'application/json; charset=UTF-8';
-      } catch(e) {
-        //Failed parsing Json, assume it is something else then
-      }
-
-      return Promise.resolve({statusCode: status, body: body, contentType: mime, revision: rev});
+            return {
+              statusCode: status, 
+              body: body, 
+              contentType: mime, 
+              revision: rev
+            }; 
+        });  
     });
   },
 

--- a/src/dropbox.js
+++ b/src/dropbox.js
@@ -406,51 +406,50 @@ Dropbox.prototype = {
       meta = resp.getResponseHeader('Dropbox-API-Result');
       //first encode the response as text, and later check if 
       //text appears to actually be binary data
-      return getTextFromArrayBuffer(resp.response, 'UTF-8')
-        .then(function (responseText) {
-          body = responseText;
-            if (status === 409) {
-              meta = body;
-            }
+      return getTextFromArrayBuffer(resp.response, 'UTF-8').then(function (responseText) {
+        body = responseText;
+        if (status === 409) {
+          meta = body;
+        }
 
-            try {
-              meta = JSON.parse(meta);
-            } catch(e) {
-              return Promise.reject(e);
-            }
+        try {
+          meta = JSON.parse(meta);
+        } catch(e) {
+          return Promise.reject(e);
+        }
 
-            if (status === 409) {
-              if (compareApiError(meta, ['path', 'not_found'])) {
-                return {statusCode: 404};
-              }
-              return Promise.reject(new Error('API error while downloading file ("' + path + '"): ' + meta.error_summary));
-            }
+        if (status === 409) {
+          if (compareApiError(meta, ['path', 'not_found'])) {
+            return {statusCode: 404};
+          }
+          return Promise.reject(new Error('API error while downloading file ("' + path + '"): ' + meta.error_summary));
+        }
 
-            mime = resp.getResponseHeader('Content-Type');
-            rev = meta.rev;
-            self._revCache.set(path, rev);
-            self._shareIfNeeded(path);
+        mime = resp.getResponseHeader('Content-Type');
+        rev = meta.rev;
+        self._revCache.set(path, rev);
+        self._shareIfNeeded(path);
 
-            if (shouldBeTreatedAsBinary(responseText, mime)) {
-              //return unprocessed response 
-              body = resp.response;
-            } else {
-              // handling json (always try)
-              try {
-                body = JSON.parse(body);
-                mime = 'application/json; charset=UTF-8';
-              } catch(e) {
-                //Failed parsing Json, assume it is something else then
-              }
-            }
+        if (shouldBeTreatedAsBinary(responseText, mime)) {
+          //return unprocessed response 
+          body = resp.response;
+        } else {
+          // handling json (always try)
+          try {
+            body = JSON.parse(body);
+            mime = 'application/json; charset=UTF-8';
+          } catch(e) {
+            //Failed parsing Json, assume it is something else then
+          }
+        }
 
-            return {
-              statusCode: status, 
-              body: body, 
-              contentType: mime, 
-              revision: rev
-            }; 
-        });  
+        return {
+          statusCode: status, 
+          body: body, 
+          contentType: mime, 
+          revision: rev
+        }; 
+      });  
     });
   },
 

--- a/src/googledrive.js
+++ b/src/googledrive.js
@@ -463,24 +463,23 @@ GoogleDrive.prototype = {
         return this._request('GET', meta.downloadUrl, params).then((response) => {
           //first encode the response as text, and later check if 
           //text appears to actually be binary data
-          return getTextFromArrayBuffer(response.response, 'UTF-8')
-            .then(function (responseText) { 
-              let body = responseText;
-              if (meta.mimeType.match(/^application\/json/)) {
-                try {
-                  body = JSON.parse(body);
-                } catch(e) {
-                  // body couldn't be parsed as JSON, so we'll just return it as is
-                }
-              } else {
-                if (shouldBeTreatedAsBinary(responseText, meta.mimeType)) {
-                  //return unprocessed response 
-                  body = response.response;
-                }
+          return getTextFromArrayBuffer(response.response, 'UTF-8').then(function (responseText) { 
+            let body = responseText;
+            if (meta.mimeType.match(/^application\/json/)) {
+              try {
+                body = JSON.parse(body);
+              } catch(e) {
+                // body couldn't be parsed as JSON, so we'll just return it as is
               }
+            } else {
+              if (shouldBeTreatedAsBinary(responseText, meta.mimeType)) {
+                //return unprocessed response 
+                body = response.response;
+              }
+            }
 
-              return {statusCode: 200, body: body, contentType: meta.mimeType, revision: etagWithoutQuotes};
-            });
+            return {statusCode: 200, body: body, contentType: meta.mimeType, revision: etagWithoutQuotes};
+          });
         });
       });
     });

--- a/src/util.js
+++ b/src/util.js
@@ -267,7 +267,45 @@ var util = {
       }
       reader.readAsArrayBuffer(blob);
     });
+  },
+
+  /**
+   * Read data from an ArrayBuffer and return it as a string
+   * @param {ArrayBuffer} arrayBuffer 
+   * @param {string} encoding 
+   * @returns {Promise} Resolves with a string containing the data
+   */
+  getTextFromArrayBuffer(arrayBuffer, encoding) {
+    return new Promise((resolve/*, reject*/) => {
+      if (typeof Blob === 'undefined') {
+        var buffer = new Buffer(new Uint8Array(arrayBuffer));
+        resolve(buffer.toString(encoding));
+      } else {
+        var blob;
+        util.globalContext.BlobBuilder = util.globalContext.BlobBuilder || util.globalContext.WebKitBlobBuilder;
+        if (typeof util.globalContext.BlobBuilder !== 'undefined') {
+          var bb = new global.BlobBuilder();
+          bb.append(arrayBuffer);
+          blob = bb.getBlob();
+        } else {
+          blob = new Blob([arrayBuffer]);
+        }
+  
+        var fileReader = new FileReader();
+        if (typeof fileReader.addEventListener === 'function') {
+          fileReader.addEventListener('loadend', function (evt) {
+            resolve(evt.target.result);
+          });
+        } else {
+          fileReader.onloadend = function(evt) {
+            resolve(evt.target.result);
+          };
+        }
+        fileReader.readAsText(blob, encoding);
+      }
+    });
   }
+  
 
 };
 

--- a/src/util.js
+++ b/src/util.js
@@ -237,39 +237,6 @@ var util = {
   },
 
   /**
-   * Read binary data and return it as ArrayBuffer.
-   *
-   * @param {string} content - The data
-   * @param {string} mimeType - The data's content-type
-   * @returns {Promise} Resolves with an ArrayBuffer containing the data
-   */
-  readBinaryData (content, mimeType) {
-    return new Promise((resolve) => {
-      let blob;
-      util.globalContext.BlobBuilder = util.globalContext.BlobBuilder || util.globalContext.WebKitBlobBuilder;
-      if (typeof util.globalContext.BlobBuilder !== 'undefined') {
-        const bb = new global.BlobBuilder();
-        bb.append(content);
-        blob = bb.getBlob(mimeType);
-      } else {
-        blob = new Blob([content], { type: mimeType });
-      }
-
-      const reader = new FileReader();
-      if (typeof reader.addEventListener === 'function') {
-        reader.addEventListener('loadend', function () {
-          resolve(reader.result); // reader.result contains the contents of blob as a typed array
-        });
-      } else {
-        reader.onloadend = function() {
-          resolve(reader.result); // reader.result contains the contents of blob as a typed array
-        };
-      }
-      reader.readAsArrayBuffer(blob);
-    });
-  },
-
-  /**
    * Read data from an ArrayBuffer and return it as a string
    * @param {ArrayBuffer} arrayBuffer 
    * @param {string} encoding 

--- a/src/util.js
+++ b/src/util.js
@@ -223,8 +223,8 @@ var util = {
   },
 
   /**
-   * Decide if data should be treated as binary based on the content
-   * and content-type.
+   * Decide if data should be treated as binary based on the content (presence of non-printable characters
+   * or replacement character) and content-type.
    *
    * @param {string} content - The data
    * @param {string} mimeType - The data's content-type
@@ -233,7 +233,7 @@ var util = {
    */
   shouldBeTreatedAsBinary (content, mimeType) {
     // eslint-disable-next-line no-control-regex
-    return (mimeType && mimeType.match(/charset=binary/)) || /[\x00-\x1F]/.test(content);
+    return (mimeType && mimeType.match(/charset=binary/)) || /[\x00-\x08\x0E-\x1F\uFFFD]/.test(content);
   },
 
   /**

--- a/src/wireclient.js
+++ b/src/wireclient.js
@@ -76,6 +76,7 @@ const isFolder = util.isFolder;
 const cleanPath = util.cleanPath;
 const shouldBeTreatedAsBinary = util.shouldBeTreatedAsBinary;
 const getJSONFromLocalStorage = util.getJSONFromLocalStorage;
+const getTextFromArrayBuffer = util.getTextFromArrayBuffer;
 
 function addQuotes(str) {
   if (typeof(str) !== 'string') {
@@ -94,37 +95,6 @@ function stripQuotes(str) {
   }
 
   return str.replace(/^["']|["']$/g, '');
-}
-
-function getTextFromArrayBuffer(arrayBuffer, encoding) {
-  return new Promise((resolve/*, reject*/) => {
-    if (typeof Blob === 'undefined') {
-      var buffer = new Buffer(new Uint8Array(arrayBuffer));
-      resolve(buffer.toString(encoding));
-    } else {
-      var blob;
-      util.globalContext.BlobBuilder = util.globalContext.BlobBuilder || util.globalContext.WebKitBlobBuilder;
-      if (typeof util.globalContext.BlobBuilder !== 'undefined') {
-        var bb = new global.BlobBuilder();
-        bb.append(arrayBuffer);
-        blob = bb.getBlob();
-      } else {
-        blob = new Blob([arrayBuffer]);
-      }
-
-      var fileReader = new FileReader();
-      if (typeof fileReader.addEventListener === 'function') {
-        fileReader.addEventListener('loadend', function (evt) {
-          resolve(evt.target.result);
-        });
-      } else {
-        fileReader.onloadend = function(evt) {
-          resolve(evt.target.result);
-        };
-      }
-      fileReader.readAsText(blob, encoding);
-    }
-  });
 }
 
 function determineCharset(mimeType) {

--- a/test/helpers/mocks.js
+++ b/test/helpers/mocks.js
@@ -97,6 +97,13 @@ define([], function() {
         this._responses = {};
       };
 
+      global.ArrayBufferMock = function(str) {
+        return {
+          iAmA: 'ArrayBufferMock',
+          content: str
+        };
+      };  
+
     },
 
     undefineMocks(env) {

--- a/test/unit/dropbox-suite.js
+++ b/test/unit/dropbox-suite.js
@@ -159,7 +159,7 @@ define(['require', './src/util', './src/dropbox', './src/wireclient',
                   'Dropbox-API-Result': JSON.stringify({rev: 'rev'})
                 },
                 status: 200,
-                responseText: '{"foo":"response-body"}'
+                arrayBuffer: new ArrayBufferMock('{"foo":"response-body"}')
               });
             }, 10);
           }
@@ -180,7 +180,7 @@ define(['require', './src/util', './src/dropbox', './src/wireclient',
                   'Dropbox-API-Result': JSON.stringify({rev: 'rev'})
                 },
                 status: 200,
-                responseText: '{"foo":"response-body"}'
+                arrayBuffer: new ArrayBufferMock('{"foo":"response-body"}')
               });              
             }, 10);
           }
@@ -201,7 +201,7 @@ define(['require', './src/util', './src/dropbox', './src/wireclient',
                   'Dropbox-API-Result': JSON.stringify({rev: 'rev'})
                 },
                 status: 200,
-                responseText: '{"foo":"response-body"}'
+                arrayBuffer: new ArrayBufferMock('{"foo":"response-body"}')
               });              
             }, 10);
           }
@@ -422,7 +422,7 @@ define(['require', './src/util', './src/dropbox', './src/wireclient',
                   'Dropbox-API-Result': JSON.stringify({rev: 'rev'})
                 },
                 status: 200,
-                responseText: 'response-body'
+                arrayBuffer: new ArrayBufferMock('response-body')
               });              
             }, 10);            
           }
@@ -444,7 +444,7 @@ define(['require', './src/util', './src/dropbox', './src/wireclient',
                   'Dropbox-API-Result': JSON.stringify({rev: 'rev'})
                 },
                 status: 200,
-                responseText: '{"response":"body"}'
+                arrayBuffer: new ArrayBufferMock('{"response":"body"}')
               });              
             }, 10);
           }
@@ -483,9 +483,9 @@ define(['require', './src/util', './src/dropbox', './src/wireclient',
               });
             mockRequestSuccess({
               status: 409,
-              responseText: JSON.stringify({
+              arrayBuffer: new ArrayBufferMock(JSON.stringify({
                 error_summary: 'path/not_found/...'
-              })
+              }))
             });
           }
         },
@@ -809,28 +809,24 @@ define(['require', './src/util', './src/dropbox', './src/wireclient',
         },
 
         {
-          desc: "responses with the charset set to 'binary' are read using a FileReader, after constructing a Blob",
+          desc: "responses with binary data are returned as an ArrayBuffer",
           run: function (env, test) {
             env.connectedClient.get('/foo/bar').
               then(function (r) {
-                // check Blob
-                test.assertTypeAnd(env.blob, 'object');
-                test.assertAnd(env.blob.input, ['response-body']);
-                test.assertAnd(env.blob.options, {
-                  type: 'application/octet-stream; charset=binary'
-                });
-
                 test.assertAnd(r.statusCode, 200);
-                test.assertAnd(r.body, env.fileReaderResult);
-                test.assert(r.contentType, 'application/octet-stream; charset=binary');
+                test.assertAnd(r.body, {
+                  iAmA: 'ArrayBufferMock',
+                  content: "\x00"
+                });
+                test.done();
               });
               mockRequestSuccess({
                 responseHeaders: {
-                  'Content-Type': 'application/octet-stream; charset=binary',
+                  'Content-Type': 'application/octet-stream',
                   'Dropbox-API-Result': JSON.stringify({rev: 'rev'})
                 },
                 status: 200,
-                responseText: 'response-body'
+                arrayBuffer: new ArrayBufferMock("\x00")
               });
           }
         },
@@ -849,7 +845,7 @@ define(['require', './src/util', './src/dropbox', './src/wireclient',
                 'Dropbox-API-Result': JSON.stringify({rev: 'rev'})
               },
               status: 200,
-              responseText: 'response-body'
+              arrayBuffer: new ArrayBufferMock('response-body')
             });
           }
         },
@@ -933,7 +929,7 @@ define(['require', './src/util', './src/dropbox', './src/wireclient',
                   'Content-Type': 'text/plain; charset=UTF-8',
                   'Dropbox-API-Result': JSON.stringify({rev: 'rev'})
                 },
-                responseText: 'response-body'
+                arrayBuffer: new ArrayBufferMock('response-body')
               });
             });
             addMockRequestCallback(function (req) {

--- a/test/unit/googledrive-suite.js
+++ b/test/unit/googledrive-suite.js
@@ -485,7 +485,70 @@ define(['util', 'require', './src/eventhandling', './src/googledrive', './src/co
             test.assert('timeout', error);
           });
         }
-      }
+      },
+
+      {
+        desc: "response from reading a binary file is returned as an ArrayBuffer",
+        run: function (env, test) {
+          env.connectedClient._fileIdCache.set('/remotestorage/foo/bar', 'abcd');
+          addMockRequestCallback(function() {
+            mockRequestSuccess({
+              status: 200,
+              responseText: JSON.stringify({
+                etag: '"foo"',
+                downloadUrl: '/download/foo',
+                mimeType: 'application/octet-stream'
+              })
+            })
+          });
+          addMockRequestCallback(function() {
+            mockRequestSuccess({
+              status: 200,
+              arrayBuffer: new ArrayBufferMock("\x00")
+            })
+          });
+          env.connectedClient.get('/foo/bar').
+            then(function (r) {
+              test.assertAnd(r.statusCode, 200);
+              test.assertAnd(r.body, {
+                iAmA: 'ArrayBufferMock',
+                content: "\x00"
+              });
+              test.done();
+            });
+        }
+      },
+
+      {
+        desc: "response from reading a text file is returned as a string",
+        run: function (env, test) {
+          env.connectedClient._fileIdCache.set('/remotestorage/foo/bar', 'abcd');
+          addMockRequestCallback(function() {
+            mockRequestSuccess({
+              status: 200,
+              responseText: JSON.stringify({
+                etag: '"foo"',
+                downloadUrl: '/download/foo',
+                mimeType: 'application/octet-stream'
+              })
+            })
+          });
+          addMockRequestCallback(function() {
+            mockRequestSuccess({
+              status: 200,
+              arrayBuffer: new ArrayBufferMock("response-body")
+            })
+          });
+          env.connectedClient.get('/foo/bar').
+            then(function (r) {
+              test.assertAnd(r.statusCode, 200);
+              test.assertAnd(r.body, 'response-body');
+              test.done();
+            });
+        }
+      },
+    
+
 
   ];
 

--- a/test/unit/node-wireclient-suite.js
+++ b/test/unit/node-wireclient-suite.js
@@ -3,16 +3,12 @@ if (typeof define !== 'function') {
 }
 define(['./src/wireclient', './src/remotestorage'], function (WireClient, RemoteStorage) {
   var suites = [];
-	var oldReadBinaryData;
 
   function setup(env, test) {
     test.assertType(RemoteStorage, 'function');
   }
 
   function takedown(env, test) {
-    if (typeof WireClient !== 'undefined') {
-      WireClient.readBinaryData = oldReadBinaryData;
-    }
     test.done();
   }
 

--- a/test/unit/wireclient-suite.js
+++ b/test/unit/wireclient-suite.js
@@ -16,13 +16,6 @@ define(['./src/sync', './src/wireclient', './src/authorize', './src/eventhandlin
   }
 
   function beforeEach(env, test) {
-    global.ArrayBufferMock = function(str) {
-      return {
-        iAmA: 'ArrayBufferMock',
-        content: str
-      };
-    };
-
     env.rs = new RemoteStorage();
     eventHandling(env.rs, 'error', 'wire-busy', 'wire-done', 'network-offline',
                   'network-online');


### PR DESCRIPTION
Fixes #1116 
Dropbox and Googledrive backends first read the response as text and then tried to convert it back to raw value, however not all bytes can be encoded as text, and are lost during the conversion to text and back. Now, they request the response as `ArrayBuffer` and encode it to text and if they detect binary data, they return the unprocessed `ArrayBuffer`.
Also made a fix to `shouldBeTreatedAsBinary` function because it was treating white space characters (horizontal tab, vertical tab, CR, LF) as binary specific characters and added the Unicode replacement character (\uFFFD) as binary specific because the decoder inserts this character when it detects an invalid code sequence for the text encoding provided.