### PR TITLE
do not return common revision if local node was marked for deletion

### DIFF
--- a/src/cachinglayer.js
+++ b/src/cachinglayer.js
@@ -32,8 +32,13 @@ function getLatest(node) {
       return node.common;
     }
   } else {
-    if (node.local && node.local.body && node.local.contentType) {
-      return node.local;
+    if (node.local) {
+      if (node.local.body && node.local.contentType) {
+        return node.local;
+      }
+      if (node.local.body === false) {
+        return;
+      }
     }
     if (node.common && node.common.body && node.common.contentType) {
       return node.common;

--- a/test/unit/cachinglayer-suite.js
+++ b/test/unit/cachinglayer-suite.js
@@ -54,6 +54,13 @@ define(['require', './src/util', './src/config', './src/inmemorystorage'], funct
             body:        'asdf',
             contentType: 'text/plain'
           };
+          deletedLocalNode = {
+            path:   '/a/b',
+            local:  { body: false },
+            common: { body: 'b', contentType: 'c' },
+            push:   { foo: 'bar' },
+            remote: { foo: 'bar' }
+          }
 
           test.assertAnd(getLatest(undefined), undefined);
           test.assertAnd(getLatest({local: { revision: 1, timestamp: 1 }}), undefined);
@@ -63,6 +70,7 @@ define(['require', './src/util', './src/config', './src/inmemorystorage'], funct
           test.assertAnd(getLatest(commonNode).contentType, 'c');
           test.assertAnd(getLatest(legacyNode).body, 'asdf');
           test.assertAnd(getLatest(legacyNode).contentType, 'text/plain');
+          test.assertAnd(getLatest(deletedLocalNode), undefined);
           test.done();
         }
       },


### PR DESCRIPTION
Fixes #1150 

If BaseClient.getObject/getFile were called after a file has been removed, but before a successful sync, they were still returning the common revision of the file, if present. This happened because the cachingLayer never checked if the local version exists but was deleted.

This issue was especially problematic when working offline and no sync was done to flush local version.