### PR TITLE
Fix detecting changes in subfolders for Dropbox

### DIFF
--- a/src/dropbox.js
+++ b/src/dropbox.js
@@ -725,7 +725,7 @@ Dropbox.prototype = {
         }
       });
     };
-    return fetch(self._fetchDeltaCursor).then(undefined, function (error) {
+    return fetch(self._fetchDeltaCursor).catch(function (error) {
       if (typeof(error) === 'object' && 'message' in error) {
         error.message = 'Dropbox: fetchDelta: ' + error.message;
       } else {

--- a/src/revisioncache.js
+++ b/src/revisioncache.js
@@ -1,16 +1,14 @@
-
 /**
- * A cache which can propagate changes up to parent folders and generate new revision 
- * ids for them. The generated revision id is consistent across different sessions.
- * The keys for the cache are case-insensitive.
+ * A cache which can propagate changes up to parent folders and generate new
+ * revision ids for them. The generated revision id is consistent across
+ * different sessions.  The keys for the cache are case-insensitive.
  *
- * @param defaultValue {string} the value that is returned for all keys that don't exist
- *                              in the cache
+ * @param defaultValue {string} the value that is returned for all keys that
+ *                              don't exist in the cache
  *
- * 
  * @class
  */
-function RevisionCache(defaultValue){
+function RevisionCache (defaultValue) {
   this.defaultValue = defaultValue;
   this._canPropagate = false;
   this._storage = { };
@@ -21,12 +19,12 @@ function RevisionCache(defaultValue){
 RevisionCache.prototype = {
   /**
    * Get a value from the cache or defaultValue, if the key is not in the
-   * cache. 
+   * cache
    */
-  get: function (key) {
+  get (key) {
     key = key.toLowerCase();
-    var stored = this._storage[key];
-    if (typeof stored === 'undefined'){
+    let stored = this._storage[key];
+    if (typeof stored === 'undefined') {
       stored = this.defaultValue;
       this._storage[key] = stored;
     }
@@ -34,9 +32,9 @@ RevisionCache.prototype = {
   },
 
   /**
-   * Set a value 
+   * Set a value
    */
-  set: function (key, value) {
+  set (key, value) {
     key = key.toLowerCase();
     if (this._storage[key] === value) {
       return value;
@@ -62,7 +60,7 @@ RevisionCache.prototype = {
   /**
    * Disables automatic update of folder revisions when a key value is updated
    */
-  deactivatePropagation: function () {
+  deactivatePropagation () {
     this._canPropagate = false;
     return true;
   },
@@ -71,7 +69,7 @@ RevisionCache.prototype = {
    * Enables automatic update of folder revisions when a key value is updated
    * and refreshes the folder revision ids for entire tree.
    */
-  activatePropagation: function (){
+  activatePropagation () {
     if (this._canPropagate) {
       return true;
     }
@@ -83,8 +81,8 @@ RevisionCache.prototype = {
   /**
    * Returns a hash code for a string.
    */
-  _hashCode: function(str) {
-    var hash = 0, i, chr;
+  _hashCode (str) {
+    let hash = 0, i, chr;
     if (str.length === 0) {
       return hash;
     }
@@ -101,23 +99,24 @@ RevisionCache.prototype = {
   /**
    * Takes an array of strings and returns a hash of the items
    */
-  _generateHash(items) {
-    //we sort the items before joining them to ensure correct hash generation every time
-    var files = items.sort().join('|');
-    var hash = ""+this._hashCode(files);
+  _generateHash (items) {
+    // We sort the items before joining them to ensure correct hash generation
+    // every time
+    const files = items.sort().join('|');
+    const hash = ""+this._hashCode(files);
     return hash;
   },
-  
+
   /**
    * Update the revision of a key in it's parent folder data
    */
-  _updateParentFolderItemRev(key, rev) {
-    if (key !== '/') { 
-      var parentFolder = this._getParentFolder(key);
+  _updateParentFolderItemRev (key, rev) {
+    if (key !== '/') {
+      const parentFolder = this._getParentFolder(key);
       if (!this._itemsRev[parentFolder]) {
         this._itemsRev[parentFolder] = {};
       }
-      var parentFolderItemsRev = this._itemsRev[parentFolder];
+      const parentFolderItemsRev = this._itemsRev[parentFolder];
       if (!rev) {
         delete parentFolderItemsRev[key];
       } else {
@@ -128,38 +127,39 @@ RevisionCache.prototype = {
     }
   },
 
-  _getParentFolder(key) {
+  _getParentFolder (key) {
     return key.substr(0, key.lastIndexOf("/",key.length - 2) + 1);
   },
 
   /**
-   * Propagate the changes to the parent folders and generate new
-   * revision ids for them
+   * Propagate the changes to the parent folders and generate new revision ids
+   * for them
    */
-  _propagate: function (key){
-    if (key !== '/') {            
-      var parentFolder = this._getParentFolder(key);
-      var parentFolderItemsRev = this._itemsRev[parentFolder];
-      var hashItems = [];
-      for (var path in parentFolderItemsRev) {
-        hashItems.push(parentFolderItemsRev[path]);        
+  _propagate (key) {
+    if (key !== '/') {
+      const parentFolder = this._getParentFolder(key);
+      const parentFolderItemsRev = this._itemsRev[parentFolder];
+      const hashItems = [];
+      for (let path in parentFolderItemsRev) {
+        hashItems.push(parentFolderItemsRev[path]);
       }
-      var newRev = this._generateHash(hashItems);
+      const newRev = this._generateHash(hashItems);
       this.set(parentFolder, newRev);
     }
   },
 
   /**
-   * Generate revision id for a folder and it's subfolders, by hashing it's listing
+   * Generate revision id for a folder and it's subfolders, by hashing it's
+   * listing
    */
-  _generateFolderRev(folder) {
-    var itemsRev = this._itemsRev[folder];
-    var hash = this.defaultValue;
+  _generateFolderRev (folder) {
+    const itemsRev = this._itemsRev[folder];
+    let hash = this.defaultValue;
     if (itemsRev) {
-      var hashItems = [];
-      for (var path in itemsRev) {
-        var isDir = path.substr(-1) === '/';
-        var hashItem;
+      const hashItems = [];
+      for (let path in itemsRev) {
+        const isDir = path.substr(-1) === '/';
+        let hashItem;
         if (isDir) {
           hashItem = this._generateFolderRev(path);
         } else {

--- a/src/revisioncache.js
+++ b/src/revisioncache.js
@@ -1,0 +1,179 @@
+
+/**
+ * A cache which can propagate changes up to parent folders and generate new revision 
+ * ids for them. The generated revision id is consistent across different sessions.
+ * The keys for the cache are case-insensitive.
+ *
+ * @param defaultValue {string} the value that is returned for all keys that don't exist
+ *                              in the cache
+ *
+ * 
+ * @class
+ */
+function RevisionCache(defaultValue){
+  this.defaultValue = defaultValue;
+  this._canPropagate = false;
+  this._storage = { };
+  this._itemsRev = {};
+  this.activatePropagation();
+}
+
+RevisionCache.prototype = {
+  /**
+   * Get a value from the cache or defaultValue, if the key is not in the
+   * cache. 
+   */
+  get: function (key) {
+    key = key.toLowerCase();
+    var stored = this._storage[key];
+    if (typeof stored === 'undefined'){
+      stored = this.defaultValue;
+      this._storage[key] = stored;
+    }
+    return stored;
+  },
+
+  /**
+   * Set a value 
+   */
+  set: function (key, value) {
+    key = key.toLowerCase();
+    if (this._storage[key] === value) {
+      return value;
+    }
+    this._storage[key] = value;
+    if (!value) {
+      delete this._itemsRev[key];
+    }
+    this._updateParentFolderItemRev(key, value);
+    if (this._canPropagate) {
+      this._propagate(key);
+    }
+    return value;
+  },
+
+  /**
+   * Delete a value
+   */
+  delete: function (key) {
+    return this.set(key, null);
+  },
+
+  /**
+   * Disables automatic update of folder revisions when a key value is updated
+   */
+  deactivatePropagation: function () {
+    this._canPropagate = false;
+    return true;
+  },
+
+  /**
+   * Enables automatic update of folder revisions when a key value is updated
+   * and refreshes the folder revision ids for entire tree.
+   */
+  activatePropagation: function (){
+    if (this._canPropagate) {
+      return true;
+    }
+    this._generateFolderRev("/");
+    this._canPropagate = true;
+    return true;
+  },
+
+  /**
+   * Returns a hash code for a string.
+   */
+  _hashCode: function(str) {
+    var hash = 0, i, chr;
+    if (str.length === 0) {
+      return hash;
+    }
+    for (i = 0; i < str.length; i++) {
+      chr   = str.charCodeAt(i);
+      // eslint-disable-next-line no-bitwise
+      hash  = ((hash << 5) - hash) + chr;
+      // eslint-disable-next-line no-bitwise
+      hash |= 0; // Convert to 32bit integer
+    }
+    return hash;
+  },
+
+  /**
+   * Takes an array of strings and returns a hash of the items
+   */
+  _generateHash(items) {
+    //we sort the items before joining them to ensure correct hash generation every time
+    var files = items.sort().join('|');
+    var hash = ""+this._hashCode(files);
+    return hash;
+  },
+  
+  /**
+   * Update the revision of a key in it's parent folder data
+   */
+  _updateParentFolderItemRev(key, rev) {
+    if (key !== '/') { 
+      var parentFolder = this._getParentFolder(key);
+      if (!this._itemsRev[parentFolder]) {
+        this._itemsRev[parentFolder] = {};
+      }
+      var parentFolderItemsRev = this._itemsRev[parentFolder];
+      if (!rev) {
+        delete parentFolderItemsRev[key];
+      } else {
+        parentFolderItemsRev[key] = rev;
+      }
+      //reset revision until root
+      this._updateParentFolderItemRev(parentFolder, this.defaultValue);
+    }
+  },
+
+  _getParentFolder(key) {
+    return key.substr(0, key.lastIndexOf("/",key.length - 2) + 1);
+  },
+
+  /**
+   * Propagate the changes to the parent folders and generate new
+   * revision ids for them
+   */
+  _propagate: function (key){
+    if (key !== '/') {            
+      var parentFolder = this._getParentFolder(key);
+      var parentFolderItemsRev = this._itemsRev[parentFolder];
+      var hashItems = [];
+      for (var path in parentFolderItemsRev) {
+        hashItems.push(parentFolderItemsRev[path]);        
+      }
+      var newRev = this._generateHash(hashItems);
+      this.set(parentFolder, newRev);
+    }
+  },
+
+  /**
+   * Generate revision id for a folder and it's subfolders, by hashing it's listing
+   */
+  _generateFolderRev(folder) {
+    var itemsRev = this._itemsRev[folder];
+    var hash = this.defaultValue;
+    if (itemsRev) {
+      var hashItems = [];
+      for (var path in itemsRev) {
+        var isDir = path.substr(-1) === '/';
+        var hashItem;
+        if (isDir) {
+          hashItem = this._generateFolderRev(path);
+        } else {
+          hashItem = itemsRev[path];
+        }
+        hashItems.push(hashItem);
+      }
+      if (hashItems.length > 0) {
+        hash = this._generateHash(hashItems);
+      }
+    }
+    this.set(folder, hash);
+    return hash;
+  }
+};
+
+module.exports = RevisionCache;

--- a/test/unit/revisioncache-suite.js
+++ b/test/unit/revisioncache-suite.js
@@ -1,0 +1,111 @@
+if (typeof(define) !== 'function') {
+  var define = require('amdefine')(module);
+}
+define(['./src/revisioncache'], function (RevisionCache) {
+  var suites = [];
+
+  suites.push({
+    name: "RevisionCache",
+    desc: "Local folders revision caching",
+    setup: function(env, test) {
+      test.done();
+    },
+
+    beforeEach: function(env, test) {
+      env.revCache = new RevisionCache('rev');
+      test.done();
+    },
+
+    tests: [
+      {
+        desc: "#set with propagation enabled updates the revision of parent folders",
+        run: function(env, test) {
+          env.revCache.activatePropagation();
+          env.revCache.set('/foo/bar',1);
+          test.assertAnd(env.revCache.get('/foo/bar'), 1);
+          test.assertFailAnd(env.revCache.get('/foo/'), 'rev');
+          test.assertFail(env.revCache.get('/'), 'rev');
+        }
+      },
+      {
+        desc: "#set with propagation disabled does not update the revision of parent folders",
+        run: function(env, test) {
+          env.revCache.deactivatePropagation();
+          env.revCache.set('/foo/bar',1);
+          test.assertAnd(env.revCache.get('/foo/bar'), 1);
+          test.assertAnd(env.revCache.get('/foo/'), 'rev');
+          test.assert(env.revCache.get('/'), 'rev');
+        }
+      },
+      {
+        desc: "#delete with propagation enabled updates the revision of parent folders",
+        run: function(env, test) {
+          env.revCache.activatePropagation();
+          env.revCache.set('/foo/bar',1);
+          var revFoo = env.revCache.get('/foo/');
+          var revRoot = env.revCache.get('/');
+          env.revCache.delete('/foo/bar');
+          test.assertAnd(env.revCache.get('/foo/bar'), null);
+          test.assertFailAnd(env.revCache.get('/foo/'), revFoo);
+          test.assertFail(env.revCache.get('/'), revRoot);
+        }
+      },
+      {
+        desc: "#delete with propagation disabled does not update the revision of parent folders",
+        run: function(env, test) {
+          env.revCache.deactivatePropagation();
+          env.revCache.set('/foo/bar',1);
+          var revFoo = env.revCache.get('/foo/');
+          var revRoot = env.revCache.get('/');
+          env.revCache.delete('/foo/bar');
+          test.assertAnd(env.revCache.get('/foo/bar'), null);
+          test.assertAnd(env.revCache.get('/foo/'), revFoo);
+          test.assert(env.revCache.get('/'), revRoot);
+        }
+      },
+      {
+        desc: "#activatePropagation updates the revision of changed folders",
+        run: function(env, test) {
+          env.revCache.deactivatePropagation();
+          env.revCache.set('/foo/bar',1);
+          env.revCache.activatePropagation();
+          test.assertFailAnd(env.revCache.get('/foo/'), 'rev');
+          test.assertFail(env.revCache.get('/'), 'rev');
+        }
+      },
+      {
+        desc: "folders revision remain the same even if changes are not provided in the same order",
+        run: function(env, test) {
+          env.revCache.activatePropagation();
+          env.revCache.set('/foo/bar',1);
+          env.revCache.set('/foo/bar2',1);
+          env.revCache.set('/foo/bar3',1);
+          env.revCache.set('/foo/bar4',1);
+          env.revCache.set('/foo2/bar',1);
+          env.revCache.set('/foo2/bar2',1);
+          env.revCache.set('/foo2/bar3',1);
+          env.revCache.set('/foo2/bar4',1);
+          var revFoo = env.revCache.get('/foo/');
+          var revFoo2 = env.revCache.get('/foo2/');
+          var revRoot = env.revCache.get('/');
+          env.revCache = new RevisionCache('rev');
+          env.revCache.activatePropagation();
+          env.revCache.set('/foo2/bar4',1);
+          env.revCache.set('/foo/bar3',1);
+          env.revCache.set('/foo2/bar3',1);
+          env.revCache.set('/foo/bar',1);
+          env.revCache.set('/foo/bar4',1);
+          env.revCache.set('/foo/bar2',1);
+          env.revCache.set('/foo2/bar2',1);
+          env.revCache.set('/foo2/bar',1);
+          test.assertAnd(env.revCache.get('/foo/'), revFoo);
+          test.assertAnd(env.revCache.get('/foo2/'), revFoo2);
+          test.assert(env.revCache.get('/'), revRoot);
+        }
+      },
+
+    ]
+  });
+
+  return suites;
+});


### PR DESCRIPTION
Fixes #1154
Continues #1158 

@iLiviu's original PR description:

> I modified the revision cache for files that Dropbox was using until now, and made it generate folder revisions by hashing the revisions of the files in it. The change of revision propagates to parent folders, and forces their revision to update so changes in subfolders can now be detected.