### PR TITLE
Don't use IndexedDB on iOS 12 and 13

### DIFF
--- a/src/indexeddb.js
+++ b/src/indexeddb.js
@@ -246,7 +246,7 @@ IndexedDB.prototype = {
           // hacky!
           this.db = other;
         }
-        if (typeof callback === 'function') { callback(self); }
+        if (typeof callback === 'function') { callback(this); }
       });
     });
   },

--- a/src/indexeddb.js
+++ b/src/indexeddb.js
@@ -403,11 +403,24 @@ IndexedDB._rs_supported = function () {
 
     // Detect browsers with known IndexedDb issues (e.g. Android pre-4.4)
     var poorIndexedDbSupport = false;
-    if (typeof navigator !== 'undefined' &&
-        navigator.userAgent.match(/Android (2|3|4\.[0-3])/)) {
-      // Chrome and Firefox support IndexedDB
-      if (!navigator.userAgent.match(/Chrome|Firefox/)) {
-        poorIndexedDbSupport = true;
+
+    if (typeof navigator !== 'undefined') {
+      const ua = navigator.userAgent;
+
+      if (ua.match(/Android (2|3|4\.[0-3])/)) {
+        // Chrome and Firefox support IndexedDB
+        if (!ua.match(/Chrome|Firefox/)) {
+          poorIndexedDbSupport = true;
+        }
+      }
+
+      // iOS 12 and 13 have serious bugs (see #1168)
+      if (ua.match(/(ipod|iphone|ipad)/i)) {
+        const versionMatch = ua.match(/os (\d+([_\s]\d+)*) like mac os x/i);
+        const version = (versionMatch && versionMatch.length > 0 && versionMatch[1]) || '';
+        if (version.match(/^1[2|3]/)) {
+          poorIndexedDbSupport = true;
+        }
       }
     }
 

--- a/test/unit/indexeddb-suite.js
+++ b/test/unit/indexeddb-suite.js
@@ -167,6 +167,35 @@ define(['./src/indexeddb', './src/config'], function (IndexedDB, config) {
         }
       },
 
+      {
+        desc: "#_rs_supported is false on iOS 13",
+        run: function(env, test) {
+          let originalIndexedDB = global.indexedDB;
+          let originalNavigator = global.navigator;
+
+          if (!global.indexedDB) {
+            global.indexedDB = {};
+          }
+          global.indexedDB.open = function () {
+            test.result(false, 'tried to access indexedDB');
+          };
+
+          if (!global.navigator) {
+            global.navigator = {};
+          }
+          global.navigator.userAgent = 'Mozilla/5.0 (iPhone; CPU iPhone OS 13_1_2 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Mobile/15E148';
+
+          IndexedDB._rs_supported().then(() => {
+            test.result(false, 'should not use indexedDB on iOS 13');
+          }).catch(() => {
+            test.result(true);
+          }).finally(() => {
+            global.navigator= originalNavigator;
+            global.indexedDB = originalIndexedDB;
+          });
+        }
+      },
+
       /* TODO: mock indexeddb with some nodejs library
       {
         desc: "getNodes, setNodes",


### PR DESCRIPTION
Refs #1168

The regex for the version detection is taken from the [Bowser project](https://github.com/lancedikson/bowser).