### PR TITLE
Handle Google Drive paths with special characters

### DIFF
--- a/src/googledrive.js
+++ b/src/googledrive.js
@@ -524,12 +524,12 @@ GoogleDrive.prototype = {
         for (const item of data.items) {
           etagWithoutQuotes = removeQuotes(item.etag);
           if (item.mimeType === GD_DIR_MIME_TYPE) {
-            this._fileIdCache.set(path + item.title + '/', item.id);
+            this._fileIdCache.set(path + cleanPath(item.title) + '/', item.id);
             itemsMap[item.title + '/'] = {
               ETag: etagWithoutQuotes
             };
           } else {
-            this._fileIdCache.set(path + item.title, item.id);
+            this._fileIdCache.set(path + cleanPath(item.title), item.id);
             itemsMap[item.title] = {
               ETag: etagWithoutQuotes,
               'Content-Type': item.mimeType,

--- a/test/unit/googledrive-suite.js
+++ b/test/unit/googledrive-suite.js
@@ -417,7 +417,7 @@ define(['util', 'require', './src/eventhandling', './src/googledrive', './src/co
             mockRequestSuccess({
               status: 200,
               responseText: JSON.stringify({ items: [
-                { etag: '"1234"' }
+                { etag: '"1234"', title: 'bar' }
               ] })
             });
           }, 10);


### PR DESCRIPTION
Paths were not encoded when used as keys for Id cache to insert data,
but when data was retrieved from cache, the paths were used encoded,
so folders with special characters were never identified as already
existing.

Fixes #1176