### PR TITLE
Fix events when not connected

### DIFF
--- a/src/authorize.ts
+++ b/src/authorize.ts
@@ -187,7 +187,10 @@ export default class Authorize {
     onFeaturesLoaded = function() {
       let authParamsUsed = false;
 
-      if (!params) { return; };
+      if (!params) {
+        remoteStorage.remote.stopWaitingForToken();
+        return;
+      };
 
       if (params.error) {
         if (params.error === 'access_denied') {


### PR DESCRIPTION
This was refactored during the TypeScript porting, which introduced a bug that prevented events from being emitted.