### PR TITLE
Fix WireClient initialization

### DIFF
--- a/src/wireclient.ts
+++ b/src/wireclient.ts
@@ -63,7 +63,9 @@ const STORAGE_APIS = {
 };
 
 function readSettings () {
-  const { userAddress, href, storageApi, token, properties } = getJSONFromLocalStorage(SETTINGS_KEY);
+  const settings = getJSONFromLocalStorage(SETTINGS_KEY) || {};
+  const { userAddress, href, storageApi, token, properties } = settings;
+
   return { userAddress, href, storageApi, token, properties };
 };
 
@@ -203,6 +205,8 @@ class WireClient {
   properties: any;
 
   constructor (rs: RemoteStorage) {
+    hasLocalStorage = localStorageAvailable();
+
     this.rs = rs;
     this.connected = false;
 
@@ -625,7 +629,6 @@ class WireClient {
   }
 
   static _rs_init (remoteStorage): void {
-    hasLocalStorage = localStorageAvailable();
     remoteStorage.remote = new WireClient(remoteStorage);
     remoteStorage.remote.online = true;
   }

--- a/test/unit/wireclient-suite.js
+++ b/test/unit/wireclient-suite.js
@@ -98,6 +98,39 @@ define(['./build/sync', './build/sync-error', './build/wireclient',
     ]
   });
 
+  suites.push({
+    name: "WireClient initialization",
+    desc: "check that instance initialization works without errors",
+    setup: function (env, test) {
+      class RemoteStorage {}
+      util.applyMixins(RemoteStorage, [EventHandling]);
+      global.RemoteStorage = RemoteStorage;
+      test.done();
+    },
+    beforeEach: function (env, test) {
+      env.rs = new RemoteStorage();
+
+      env.oldLocalStorageAvailable = util.localStorageAvailable;
+      util.localStorageAvailable = function() { return true; };
+
+      test.done();
+    },
+    afterEach: function (env, test) {
+      util.localStorageAvailable = env.oldLocalStorageAvailable;
+      test.done();
+    },
+    tests: [
+      {
+        desc: "works when there are no settings in localStorage",
+        run: function(env, test) {
+          WireClient._rs_init(env.rs);
+
+          test.result(true);
+        }
+      }
+    ]
+  });
+
   var tests = [
       {
         desc: "reports that it is supported by this HTTP request API",
@@ -986,8 +1019,9 @@ define(['./build/sync', './build/sync-error', './build/wireclient',
           test.assertTypeAnd(req._onerror, 'function');
           test.done();
         }
-      },
+      }
     ]);
+
     suites.push({
        name: "WireClient (using XMLHttpRequest)",
        desc: "Low-level remotestorage client",
@@ -998,8 +1032,8 @@ define(['./build/sync', './build/sync-error', './build/wireclient',
     });
 
     var fetchTests = tests.concat([
-
     ]);
+
     suites.push({
        name: "WireClient (using fetch)",
        desc: "Low-level remotestorage client",


### PR DESCRIPTION
This fixes an error thrown during library initialization:

> TypeError: this.remote is undefined

It happens when there are no settings for the WireClient in localStorage (i.e. userAddress, token, ...), preventing the WireClient instance to be created. The error that is (silently) thrown is

>  TypeError: Cannot destructure property 'userAddress' of 'util.getJSONFromLocalStorage(...)' as it is null.