### PR TITLE
Remove usage of require().default when using RemoteStorage in node

### DIFF
--- a/src/access.ts
+++ b/src/access.ts
@@ -18,7 +18,7 @@ interface ScopeModeMap {
  *
  * Keeps track of claimed access and scopes.
  */
-export default class Access {
+class Access {
   scopeModeMap: ScopeModeMap;
   rootPaths: string[];
   storageType: string;
@@ -177,3 +177,5 @@ export default class Access {
     this.storageType = type;
   }
 }
+
+export = Access;

--- a/src/authorize.ts
+++ b/src/authorize.ts
@@ -72,7 +72,7 @@ function buildOAuthURL (authURL: string, redirectUri: string, scope: string, cli
   return url;
 }
 
-export default class Authorize {
+class Authorize {
   static IMPLIED_FAKE_TOKEN = false;
 
   static authorize (remoteStorage, { authURL, scope, redirectUri, clientId }: AuthOptions): void {
@@ -233,3 +233,5 @@ export default class Authorize {
     remoteStorage.removeEventListener('features-loaded', onFeaturesLoaded);
   };
 };
+
+export = Authorize;

--- a/src/baseclient.ts
+++ b/src/baseclient.ts
@@ -462,8 +462,7 @@ class BaseClient {
   }
 }
 
-
 interface BaseClient extends EventHandling {};
 applyMixins(BaseClient, [EventHandling]);
 
-export default BaseClient;
+export = BaseClient;

--- a/src/caching.ts
+++ b/src/caching.ts
@@ -6,7 +6,7 @@ import log from './log';
  *
  * Holds/manages caching configuration.
  **/
-export default class Caching {
+class Caching {
   pendingActivations: string[] = [];
   // TODO add correct type
   activateHandler: Function;
@@ -122,3 +122,5 @@ export default class Caching {
     return;
   }
 }
+
+export = Caching;

--- a/src/cachinglayer.ts
+++ b/src/cachinglayer.ts
@@ -438,4 +438,4 @@ function updateFolderNodeWithItemName(node: RSNode, itemName: string): RSNode {
 interface CachingLayer extends EventHandling {};
 applyMixins(CachingLayer, [EventHandling]);
 
-export default CachingLayer;
+export = CachingLayer;

--- a/src/config.ts
+++ b/src/config.ts
@@ -23,4 +23,4 @@ const config = {
   syncInterval: 10000
 };
 
-export default config;
+export = config;

--- a/src/discover.ts
+++ b/src/discover.ts
@@ -105,4 +105,4 @@ Discover._rs_cleanup = function (): void {
 };
 
 
-export default Discover;
+export = Discover;

--- a/src/dropbox.ts
+++ b/src/dropbox.ts
@@ -1139,4 +1139,4 @@ function unHookIt(rs){
 interface Dropbox extends EventHandling {};
 applyMixins(Dropbox, [EventHandling]);
 
-export default Dropbox;
+export = Dropbox;

--- a/src/env.ts
+++ b/src/env.ts
@@ -72,4 +72,4 @@ class Env {
 interface Env extends EventHandling {};
 applyMixins(Env, [EventHandling]);
 
-export default Env;
+export = Env;

--- a/src/eventhandling.ts
+++ b/src/eventhandling.ts
@@ -3,7 +3,7 @@ import log from './log';
 // TODO add real type for event
 type EventHandler = (event?: unknown) => void;
 
-export default class EventHandling {
+class EventHandling {
   _handlers: { [key: string]: EventHandler[] };
 
   /**
@@ -78,3 +78,5 @@ export default class EventHandling {
     this._handlers[eventName] = [];
   }
 }
+
+export = EventHandling;

--- a/src/features.ts
+++ b/src/features.ts
@@ -254,4 +254,4 @@ const Features = {
   }
 };
 
-export default Features;
+export = Features;

--- a/src/googledrive.ts
+++ b/src/googledrive.ts
@@ -795,4 +795,4 @@ class GoogleDrive {
 interface GoogleDrive extends EventHandling {};
 applyMixins(GoogleDrive, [EventHandling]);
 
-export default GoogleDrive;
+export = GoogleDrive;

--- a/src/indexeddb.ts
+++ b/src/indexeddb.ts
@@ -388,7 +388,7 @@ class IndexedDB extends CachingLayer {
    * @protected
    */
   // TODO add real type once known
-  static _rs_init (remoteStorage: unknown): Promise<unknown> {
+  static _rs_init (remoteStorage: unknown): Promise<void> {
 
     return new Promise((resolve, reject) => {
 
@@ -484,4 +484,4 @@ class IndexedDB extends CachingLayer {
 interface IndexedDB extends EventHandling {};
 applyMixins(IndexedDB, [EventHandling]);
 
-export default IndexedDB;
+export = IndexedDB;

--- a/src/inmemorystorage.ts
+++ b/src/inmemorystorage.ts
@@ -88,4 +88,4 @@ class InMemoryStorage extends CachingLayer {
 interface InMemoryStorage extends EventHandling {};
 applyMixins(InMemoryStorage, [EventHandling]);
 
-export default InMemoryStorage;
+export = InMemoryStorage;

--- a/src/localstorage.ts
+++ b/src/localstorage.ts
@@ -118,4 +118,4 @@ class LocalStorage extends CachingLayer {
 interface LocalStorage extends EventHandling {};
 applyMixins(LocalStorage, [EventHandling]);
 
-export default LocalStorage;
+export = LocalStorage;

--- a/src/log.ts
+++ b/src/log.ts
@@ -8,9 +8,11 @@ import config from './config';
  * (You can also enable logging during remoteStorage object creation. See:
  * {@link RemoteStorage}).
  */
-export default function log(...args): void {
+function log(...args): void {
   if (config.logging) {
     // eslint-disable-next-line no-console
     console.log(...args);
   }
 }
+
+export = log;

--- a/src/remotestorage.ts
+++ b/src/remotestorage.ts
@@ -948,4 +948,4 @@ Object.defineProperty(RemoteStorage.prototype, 'caching', {
 interface RemoteStorage extends EventHandling {};
 applyMixins(RemoteStorage, [EventHandling]);
 
-export default RemoteStorage;
+export = RemoteStorage;

--- a/src/revisioncache.ts
+++ b/src/revisioncache.ts
@@ -180,4 +180,4 @@ class RevisionCache {
   }
 }
 
-export default RevisionCache;
+export = RevisionCache;

--- a/src/schema-not-found-error.ts
+++ b/src/schema-not-found-error.ts
@@ -1,4 +1,4 @@
-export default class SchemaNotFound extends Error {
+class SchemaNotFound extends Error {
   constructor(uri: string) {
     super();
     const error = new Error("Schema not found: " + uri);
@@ -6,3 +6,5 @@ export default class SchemaNotFound extends Error {
     return error;
   }
 }
+
+export = SchemaNotFound;

--- a/src/sync-error.ts
+++ b/src/sync-error.ts
@@ -1,4 +1,4 @@
-export default class SyncError extends Error {
+class SyncError extends Error {
   originalError: Error
 
   constructor (originalError: string | Error) {
@@ -14,3 +14,5 @@ export default class SyncError extends Error {
     }
   }
 }
+
+export = SyncError;

--- a/src/sync.ts
+++ b/src/sync.ts
@@ -1080,4 +1080,4 @@ class Sync {
 interface Sync extends EventHandling {};
 applyMixins(Sync, [EventHandling]);
 
-export default Sync;
+export = Sync;

--- a/src/syncedgetputdelete.ts
+++ b/src/syncedgetputdelete.ts
@@ -60,4 +60,4 @@ const SyncedGetPutDelete = {
   }
 };
 
-export default SyncedGetPutDelete;
+export = SyncedGetPutDelete;

--- a/src/unauthorized-error.ts
+++ b/src/unauthorized-error.ts
@@ -1,4 +1,4 @@
-export default class UnauthorizedError extends Error {
+class UnauthorizedError extends Error {
   code: string;
 
   constructor (message?: string, options: {code?: string} = {}) {
@@ -18,3 +18,5 @@ export default class UnauthorizedError extends Error {
     this.stack = (new Error()).stack;
   };
 }
+
+export = UnauthorizedError;

--- a/src/wireclient.ts
+++ b/src/wireclient.ts
@@ -644,4 +644,4 @@ class WireClient {
 interface WireClient extends EventHandling {};
 applyMixins(WireClient, [EventHandling]);
 
-export default WireClient;
+export = WireClient;

--- a/test/unit/access-suite.js
+++ b/test/unit/access-suite.js
@@ -7,10 +7,9 @@ define(['require', 'fs'], function( require, fs, undefined) {
     name: "access",
     desc: "access knows all about the scope we claimed and which paths that gives us access to",
     setup: function(env, test) {
-
       global.RemoteStorage = function() {};
       RemoteStorage.log = function() {};
-      RemoteStorage.Access = require('../../build/access').default;
+      RemoteStorage.Access = require('../../build/access');
 
       env.Access = RemoteStorage.Access;
 

--- a/test/unit/authorize-suite.js
+++ b/test/unit/authorize-suite.js
@@ -10,8 +10,8 @@ define([ 'require', './build/authorize', './build/unauthorized-error'], function
     setup: function(env, test) {
       global.RemoteStorage = function() {};
       RemoteStorage.log = function() {};
-      env.Authorize = Authorize.default;
-      env.UnauthorizedError = UnauthorizedError.default;
+      env.Authorize = Authorize;
+      env.UnauthorizedError = UnauthorizedError;
       test.done();
     },
 

--- a/test/unit/baseclient-suite.js
+++ b/test/unit/baseclient-suite.js
@@ -2,10 +2,9 @@ if (typeof define !== 'function') {
   var define = require('amdefine')(module);
 }
 define(['./build/config', './build/baseclient', 'test/helpers/mocks', 'tv4'],
-       function (config, BC, mocks, tv4) {
+       function (config, BaseClient, mocks, tv4) {
 
   var suites = [];
-  var BaseClient = BC.default;
 
   suites.push({
     name: "BaseClient",

--- a/test/unit/baseclient/types-suite.js
+++ b/test/unit/baseclient/types-suite.js
@@ -8,7 +8,7 @@ define(['require'], function(require) {
     name: "BaseClient.Types",
     desc: "Type and schema handling",
     setup: function(env, test) {
-      global.BaseClient = require('../build/baseclient').default;
+      global.BaseClient = require('../build/baseclient');
       global.RemoteStorage = function() {};
       RemoteStorage.log = function() {};
       RemoteStorage.prototype.onChange = function() {};

--- a/test/unit/caching-suite.js
+++ b/test/unit/caching-suite.js
@@ -9,7 +9,7 @@ define(['require'], function(require) {
     name: "caching",
     desc: "Caching stores settings about which paths to cache locally",
     setup: function(env, test) {
-      env.Caching = require('./build/caching').default;
+      env.Caching = require('./build/caching');
 
       test.result(true);
     },

--- a/test/unit/cachinglayer-suite.js
+++ b/test/unit/cachinglayer-suite.js
@@ -3,8 +3,6 @@ if (typeof(define) !== 'function') {
 }
 define(['require', './build/util', './build/config', './build/inmemorystorage'], function (require, util, config, InMemoryStorage) {
   var suites = [];
-  var config = config.default;
-  var InMemoryStorage = InMemoryStorage.default;
 
   function stringToArrayBuffer(str) {
     var buf = new ArrayBuffer(str.length * 2);

--- a/test/unit/discover-suite.js
+++ b/test/unit/discover-suite.js
@@ -10,7 +10,7 @@ define(['require', 'fs'], function (require, fs) {
     setup: function(env, test) {
       global.XMLHttpRequest = require('xhr2');
       global.WebFinger = require('webfinger.js')
-      global.Discover = require('./build/discover').default;
+      global.Discover = require('./build/discover');
       global.RemoteStorage = function() {};
       RemoteStorage.log = function() {};
       global.RemoteStorage.prototype.localStorageAvailable = function() { return false; };

--- a/test/unit/dropbox-suite.js
+++ b/test/unit/dropbox-suite.js
@@ -8,10 +8,6 @@ define(['require', './build/util', './build/dropbox', './build/wireclient',
                  buildUtil, backend, mocks) {
 
     var suites = [];
-    var Dropbox = Dropbox.default;
-    var WireClient = WireClient.default;
-    var EventHandling = EventHandling.default;
-    var config = config.default;
 
     function setup(env, test) {
       class RemoteStorage {
@@ -32,7 +28,7 @@ define(['require', './build/util', './build/dropbox', './build/wireclient',
         return false;
       };
 
-      global.Authorize = require('./build/authorize').default;
+      global.Authorize = require('./build/authorize');
 
       test.done();
     }

--- a/test/unit/googledrive-suite.js
+++ b/test/unit/googledrive-suite.js
@@ -8,9 +8,6 @@ define(['util', 'require', './build/eventhandling', './build/googledrive',
                  backend, mocks) {
 
   var suites = [];
-  var EventHandling = EventHandling.default;
-  var GoogleDrive = GoogleDrive.default;
-  var config = config.default;
 
   function setup (env, test) {
     global.localStorage = {
@@ -24,7 +21,7 @@ define(['util', 'require', './build/eventhandling', './build/googledrive',
     buildUtil.applyMixins(RemoteStorage, [EventHandling]);
     global.RemoteStorage = RemoteStorage;
 
-    global.Authorize = require('./build/authorize').default;
+    global.Authorize = require('./build/authorize');
 
     test.done();
   }
@@ -68,7 +65,7 @@ define(['util', 'require', './build/eventhandling', './build/googledrive',
   function beforeEachFetch(env, test) {
     beforeEach(env, test);
     mocks.defineFetchMock(env);
-  }    
+  }
 
   function afterEach(env, test) {
     mocks.undefineMocks(env);
@@ -198,7 +195,7 @@ define(['util', 'require', './build/eventhandling', './build/googledrive',
                 }
               }
             })
-          });            
+          });
         }, 10);
       }
     },
@@ -222,7 +219,7 @@ define(['util', 'require', './build/eventhandling', './build/googledrive',
       run: function (env, test) {
         addMockRequestCallback(function(req) {
           test.assert(getMockRequestHeader('Authorization'), 'Bearer ' + env.token);
-        });          
+        });
         env.connectedClient.get('/foo/bar').then(function () {
           test.result(false, 'get call should not return successful');
         }).catch(function (err) {

--- a/test/unit/indexeddb-suite.js
+++ b/test/unit/indexeddb-suite.js
@@ -3,8 +3,6 @@ if (typeof(define) !== 'function') {
 }
 define(['./build/indexeddb', './build/config'], function (IndexedDB, config) {
   var suites = [];
-  var IndexedDB = IndexedDB.default;
-  var config = config.default;
 
   suites.push({
     name: "IndexedDB",

--- a/test/unit/inmemorycaching-suite.js
+++ b/test/unit/inmemorycaching-suite.js
@@ -3,8 +3,6 @@ if (typeof(define) !== 'function') {
 }
 define(['./build/config', './build/inmemorystorage'], function (config, InMemoryStorage) {
   var suites = [];
-  var config = config.default;
-  var InMemoryStorage = InMemoryStorage.default;
 
   suites.push({
     name: 'InMemoryStorage',

--- a/test/unit/localstorage-suite.js
+++ b/test/unit/localstorage-suite.js
@@ -3,8 +3,6 @@ if (typeof(define) !== 'function') {
 }
 define(['./build/config', './build/localstorage'], function (config, LocalStorage) {
   var suites = [];
-  var config = config.default;
-  var LocalStorage = LocalStorage.default;
 
   var NODES_PREFIX = 'remotestorage:cache:nodes:';
   var CHANGES_PREFIX = 'remotestorage:cache:changes:';

--- a/test/unit/modules-suite.js
+++ b/test/unit/modules-suite.js
@@ -1,9 +1,8 @@
 if (typeof(define) !== 'function') {
   var define = require('amdefine');
 }
-define(['./build/remotestorage'], function(RS) {
+define(['./build/remotestorage'], function(RemoteStorage) {
   var suites = [];
-  var RemoteStorage = RS.default;
 
   suites.push({
     name: "modules",

--- a/test/unit/node-wireclient-suite.js
+++ b/test/unit/node-wireclient-suite.js
@@ -3,8 +3,6 @@ if (typeof define !== 'function') {
 }
 define(['./build/wireclient', './build/remotestorage'], function (WireClient, RemoteStorage) {
   var suites = [];
-  var WireClient = WireClient.default;
-  var RemoteStorage = RemoteStorage.default;
 
   function setup(env, test) {
     test.assertType(RemoteStorage, 'function');

--- a/test/unit/remotestorage-suite.js
+++ b/test/unit/remotestorage-suite.js
@@ -30,7 +30,7 @@ define(['require', 'tv4', './build/eventhandling', './build/util'],
   FakeRemote.prototype.get = fakeRequest;
   FakeRemote.prototype.put = fakeRequest;
   FakeRemote.prototype.delete = fakeRequest;
-  util.applyMixins(FakeRemote, [EventHandling.default]);
+  util.applyMixins(FakeRemote, [EventHandling]);
 
   function FakeLocal() {}
 
@@ -67,14 +67,14 @@ define(['require', 'tv4', './build/eventhandling', './build/util'],
     desc: "the RemoteStorage instance",
     setup:  function(env, test) {
       global.XMLHttpRequest = require('xhr2').XMLHttpRequest;
-      global.SyncedGetPutDelete = require('./build/syncedgetputdelete').default;
-      global.Authorize = require('./build/authorize').default;
-      global.UnauthorizedError = require('./build/unauthorized-error').default;
-      global.Sync = require('./build/sync').default;
-      global.config = require('./build/config').default;
-      global.log = require('./build/log').default;
-      global.Dropbox = require('./build/dropbox').default;
-      global.RemoteStorage = require('./build/remotestorage').default;
+      global.SyncedGetPutDelete = require('./build/syncedgetputdelete');
+      global.Authorize = require('./build/authorize');
+      global.UnauthorizedError = require('./build/unauthorized-error');
+      global.Sync = require('./build/sync');
+      global.config = require('./build/config');
+      global.log = require('./build/log');
+      global.Dropbox = require('./build/dropbox');
+      global.RemoteStorage = require('./build/remotestorage');
 
       global.Discover = function(userAddress) {
         var pending = Promise.defer();
@@ -749,7 +749,7 @@ define(['require', 'tv4', './build/eventhandling', './build/util'],
     },
 
     beforeEach: function(env, test) {
-      global.log = require('./build/log').default;
+      global.log = require('./build/log');
       fakeLogs = [];
       test.done();
     },

--- a/test/unit/revisioncache-suite.js
+++ b/test/unit/revisioncache-suite.js
@@ -3,7 +3,6 @@ if (typeof(define) !== 'function') {
 }
 define(['./build/revisioncache'], function (RevisionCache) {
   var suites = [];
-  var RevisionCache = RevisionCache.default;
 
   suites.push({
     name: "RevisionCache",

--- a/test/unit/sync-suite.js
+++ b/test/unit/sync-suite.js
@@ -12,18 +12,18 @@ define(['./build/util', 'require', 'test/helpers/mocks'], function(util, require
     setup: function(env, test){
       mocks.defineMocks(env);
 
-      global.Authorize = require('./build/authorize').default;
-      global.UnauthorizedError = require('./build/unauthorized-error').default;
-      global.config = require('./build/config').default;
-      global.EventHandling = require('./build/eventhandling').default;
-      global.Sync = require('./build/sync').default;
-      global.InMemoryStorage = require('./build/inmemorystorage').default;
+      global.Authorize = require('./build/authorize');
+      global.UnauthorizedError = require('./build/unauthorized-error');
+      global.config = require('./build/config');
+      global.EventHandling = require('./build/eventhandling');
+      global.Sync = require('./build/sync');
+      global.InMemoryStorage = require('./build/inmemorystorage');
 
       class RemoteStorage { static log () {} }
       util.applyMixins(RemoteStorage, [EventHandling]);
       global.RemoteStorage = RemoteStorage;
 
-      var RS = require('./build/remotestorage').default;
+      var RS = require('./build/remotestorage');
       RemoteStorage.prototype.stopSync = RS.prototype.stopSync;
       RemoteStorage.prototype.startSync = RS.prototype.startSync;
       RemoteStorage.prototype.getSyncInterval = RS.prototype.getSyncInterval;

--- a/test/unit/versioning-suite.js
+++ b/test/unit/versioning-suite.js
@@ -8,10 +8,6 @@ define(['./build/config', './build/eventhandling', './build/inmemorystorage',
                  mocks) {
 
   var suites = [];
-  var config = config.default;
-  var EventHandling = EventHandling.default;
-  var InMemoryStorage = InMemoryStorage.default;
-  var Sync = Sync.default;
 
   function flatten(array){
     var flat = [];

--- a/test/unit/wireclient-suite.js
+++ b/test/unit/wireclient-suite.js
@@ -8,12 +8,6 @@ define(['./build/sync', './build/sync-error', './build/wireclient',
                 config, util, backend, mocks, undefined) {
 
   var suites = [];
-  var Sync = Sync.default;
-  var SyncError = SyncError.default;
-  var WireClient = WireClient.default;
-  var Authorize = Authorize.default;
-  var EventHandling = EventHandling.default;
-  var config = config.default;
 
   function setup(env, test) {
     class RemoteStorage {


### PR DESCRIPTION
Refs #1191

I found a feature of TypeScript that prevents needing to use `require().default`
in node, when a module only has a single export.

Instead of `export default Foo` you can just use `export = Foo`.