### PR TITLE
Generate separate sourcemap instead of inlining it

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -15,7 +15,7 @@ const plugins = isProd ? [
 
 module.exports = {
   entry: ['./src/remotestorage.ts'],
-  devtool: 'inline-source-map',
+  devtool: 'source-map',
   // the only external dependecy is xmlhttprequest because it is
   // different in browser and in node env so user has to manage with that
   externals: ['xmlhttprequest'],


### PR DESCRIPTION
Inlining the sourcemap in the build file increases the filesize quite a lot.

This changes it back to a separate file as it was in 1.x.