### PR TITLE
Throw error instead of string

### DIFF
--- a/src/baseclient.ts
+++ b/src/baseclient.ts
@@ -222,7 +222,7 @@ class BaseClient {
         try {
           return JSON.parse(r.body);
         } catch (e) {
-          throw "Not valid JSON: " + this.makePath(path);
+          throw new Error("Not valid JSON: " + this.makePath(path));
         }
       } else if (typeof (r.body) !== 'undefined' && r.statusCode === 200) {
         return Promise.reject("Not an object: " + this.makePath(path));


### PR DESCRIPTION
I am not able to `catch` this error in mocha because it's a string. Might be useful to do this throughout the code but I don't know if there will be side effects. Tests seem to pass with this change.