### PR TITLE
Fix potentially wrong command in warning message

### DIFF
--- a/src/remotestorage.ts
+++ b/src/remotestorage.ts
@@ -695,7 +695,7 @@ class RemoteStorage {
 
     if (!this.access.checkPathPermission(path, 'r')) {
       const escapedPath = path.replace(/(['\\])/g, '\\$1');
-      console.warn('WARNING: please call remoteStorage.access.claim(\'' + escapedPath + '\', \'r\') (read only) or remoteStorage.access.claim(\'' + escapedPath + '\', \'rw\') (read/write) first');
+      console.warn('WARNING: Please use remoteStorage.access.claim() to ask for access permissions first: https://remotestoragejs.readthedocs.io/en/latest/js-api/access.html#claim');
     }
     return new BaseClient(this, path);
   }

--- a/src/remotestorage.ts
+++ b/src/remotestorage.ts
@@ -692,9 +692,7 @@ class RemoteStorage {
     if (typeof(path) !== 'string') {
       throw 'Argument \'path\' of baseClient.scope must be a string';
     }
-
     if (!this.access.checkPathPermission(path, 'r')) {
-      const escapedPath = path.replace(/(['\\])/g, '\\$1');
       console.warn('WARNING: Please use remoteStorage.access.claim() to ask for access permissions first: https://remotestoragejs.readthedocs.io/en/latest/js-api/access.html#claim');
     }
     return new BaseClient(this, path);


### PR DESCRIPTION
Improves the warning message by removing the exact command entirely and referring to the proper documentation instead.

Replaces #1217.

![Screenshot from 2021-02-15 11-44-37](https://user-images.githubusercontent.com/842/107938171-3eceb600-6f85-11eb-946d-f511b6694df1.png)