### PR TITLE
Use conda to fetch Node.js for ReadTheDocs

### DIFF
--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -1,6 +1,4 @@
 version: 2
 
-python:
-  version: 3.8
-  install:
-    - requirements: doc/requirements.txt
+conda:
+  environment: doc/environment.yml

--- a/doc/build-with-conda.sh
+++ b/doc/build-with-conda.sh
@@ -1,0 +1,19 @@
+#!/bin/bash
+
+# This script replicates the build process that ReadTheDocs uses, at least as well as it can
+
+# Get script location/path: https://stackoverflow.com/a/246128
+SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
+# Enter repository root
+cd "$SCRIPT_DIR/.." || exit 1
+
+# Setup conda environment
+conda env create --quiet --name rtd_env --file doc/environment.yml
+conda install --yes --quiet --name rtd_env mock pillow sphinx sphinx_rtd_theme
+# Store conda bin path for later use
+CONDA_BIN=/home/docs/.conda/envs/rtd_env/bin
+"$CONDA_BIN/python" -m pip install -U --no-cache-dir recommonmark six readthedocs-sphinx-ext
+
+# Build docs
+cd doc || exit 1
+"$CONDA_BIN/python" -m sphinx -v -T -E -b html -d _build/doctrees -D language=en . _build/html

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -15,6 +15,7 @@
 # add these directories to sys.path here. If the directory is relative to the
 # documentation root, use os.path.abspath to make it absolute, like shown here.
 #
+import datetime
 import os
 import sys
 sys.path.insert(0, os.path.abspath('.'))
@@ -61,7 +62,9 @@ master_doc = 'index'
 
 # General information about the project.
 project = 'remoteStorage.js'
-copyright = '2012-2020, RS Contributors'
+copyright = '2012-{current_year}, RS Contributors'.format(
+    current_year=datetime.date.today().strftime("%Y")
+)
 author = 'RS Contributors'
 
 # The version info for the project you're documenting, acts as replacement for
@@ -187,7 +190,29 @@ texinfo_documents = [
 
 #
 # HACKFIX WARNING
+# TODO Remove this when RTD updates their Node.js version
+# https://github.com/readthedocs/readthedocs-docker-images/issues/107
+#
+# Manually add custom Node.js/npm from conda to PATH
+python_executable_directory = sys.path.insert(0, os.path.abspath(sys.executable + "/.."))
+os.environ["PATH"] = f"{python_executable_directory}:{os.environ['PATH']}"
+# Verify Node.js version is correct
+os.system('node --version')
+os.system('npm --version')
+
+#
+# HACKFIX WARNING
 # TODO Remove this when there is official support for pre-build steps on RTD
 # https://github.com/readthedocs/readthedocs.org/issues/6662
 #
 os.system('npm install')
+
+#
+# HACKFIX WARNING
+# TODO Remove this when RTD updates their Node.js version
+# https://github.com/readthedocs/readthedocs-docker-images/issues/107
+#
+# Manually add typedoc to PATH
+typedoc_directory = os.path.abspath('../node_modules/typedoc/bin')
+os.system(f'chmod +x {typedoc_directory}/typedoc')
+os.environ["PATH"] = f"{typedoc_directory}:{os.environ['PATH']}"

--- a/doc/contributing/docs.rst
+++ b/doc/contributing/docs.rst
@@ -64,6 +64,31 @@ This will start a web server, serving rendered HTML docs on `<http://localhost:8
    will need to re-run the command, or change something in a ``.rst`` file in
    order for code documentation changes to be re-built.
 
+How to build the docs using ReadTheDocs' Docker image
+-----------------------------------------------------
+
+This is useful for troubleshooting when the ReadTheDocs build is failing.
+
+Setup
+^^^^^
+
+1. `Install Docker <https://docs.docker.com/get-docker/>`_
+
+2. Pull the latest version of ``readthedocs/build`` image with the ``latest`` tag from Docker Hub::
+
+    $ docker pull readthedocs/build:latest
+
+Build
+^^^^^
+
+1. Enter a ``bash`` session while attaching this project as a volume::
+
+    $ docker run --rm -it -v ${PWD}:/app readthedocs/build:latest bash
+
+2. Run the ``build-with-conda.sh`` script to setup conda environment and build the docs like ReadTheDocs::
+
+    $ /app/doc/build-with-conda.sh
+
 .. rubric:: Footnotes
 
 .. [#f1] Every single bit helps other people! Even fixing a typo is worth a

--- a/doc/environment.yml
+++ b/doc/environment.yml
@@ -1,0 +1,13 @@
+name: rtd_env
+channels:
+  - conda-forge
+  - defaults
+dependencies:
+  - nodejs=14.15.1
+  - pip=21.0.1
+  - python=3.8.5
+  - pip:
+    - sphinx-js >= 3.1
+    - sphinx-issues
+    - sphinx-autobuild
+    - sphinx_rtd_theme

--- a/package-lock.json
+++ b/package-lock.json
@@ -1835,6 +1835,16 @@
       "dev": true,
       "optional": true
     },
+    "bindings": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/bindings/-/bindings-1.5.0.tgz",
+      "integrity": "sha1-EDU8npRTNLwFEabZCzj7x8nFBN8=",
+      "dev": true,
+      "optional": true,
+      "requires": {
+        "file-uri-to-path": "1.0.0"
+      }
+    },
     "bluebird": {
       "version": "3.5.3",
       "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-3.5.3.tgz",
@@ -3475,6 +3485,13 @@
       "requires": {
         "flat-cache": "^2.0.1"
       }
+    },
+    "file-uri-to-path": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/file-uri-to-path/-/file-uri-to-path-1.0.0.tgz",
+      "integrity": "sha1-VTp7hEb/b2hDWcRF8eN6BdrMM90=",
+      "dev": true,
+      "optional": true
     },
     "fill-range": {
       "version": "4.0.0",
@@ -6693,7 +6710,11 @@
           "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-1.2.13.tgz",
           "integrity": "sha512-oWb1Z6mkHIskLzEJ/XWX0srkpkTQ7vaopMQkyaEIoq0fmtFVxOthb8cCxeT+p3ynTdkk/RZwbgG4brR5BeWECw==",
           "dev": true,
-          "optional": true
+          "optional": true,
+          "requires": {
+            "bindings": "^1.5.0",
+            "nan": "^2.12.1"
+          }
         },
         "glob-parent": {
           "version": "3.1.0",
@@ -6727,6 +6748,13 @@
           "requires": {
             "binary-extensions": "^1.0.0"
           }
+        },
+        "nan": {
+          "version": "2.14.2",
+          "resolved": "https://registry.npmjs.org/nan/-/nan-2.14.2.tgz",
+          "integrity": "sha1-9TdkAGlRaPTMaUrJOT0MlYXu6hk=",
+          "dev": true,
+          "optional": true
         },
         "readdirp": {
           "version": "2.2.1",


### PR DESCRIPTION
I was checking out this project when I noticed there was issues with ReadTheDocs, so I figured I'd try to provide some assistance. Feel free to use this PR or incorporate it into your existing #1207. Let me know if you have any questions!

<hr>

ReadTheDocs builds are failing on the main branch due to the need for the latest Node.js. This is a temporary fix by installing a manually specified binary on the documentation building machine.

Locally, this works as expected. When running the Docker container without `update-node-and-npm-without-sudo.sh` results in the same errors found here: https://readthedocs.org/projects/remotestoragejs/builds/13065050/

After adding the script to `conf.py` the documentation is able to build normally.

Also, I added an auto-update for the copyright.