### PR TITLE
Fix Code Climate builds

### DIFF
--- a/.codeclimate.yml
+++ b/.codeclimate.yml
@@ -1,9 +1,9 @@
 ---
 version: "2"
-engines:
+plugins:
   eslint:
     enabled: true
-    channel: "eslint-4"
+    channel: "eslint-7"
   duplication:
     enabled: true
     config:
@@ -12,10 +12,7 @@ engines:
 checks:
   file-lines:
     enabled: false
-ratings:
-  paths:
-    - src/**
-exclude_paths:
+exclude_patterns:
   - doc/
   - node_modules/
   - release/


### PR DESCRIPTION
Currently, Code Climate builds are failing: https://codeclimate.com/github/remotestorage/remotestorage.js/builds/430

This change addresses the following:

* Fix all errors/warnings when running the CodeClimate CLI `codeclimate validate-config`
* Update `eslint` plugin to match `package.json`

This change was validated by running `codeclimate analyze` without errors.

CodeClimate CLI for reference: https://github.com/codeclimate/codeclimate

Edit: Demonstration of the build passing https://codeclimate.com/github/remotestorage/remotestorage.js/builds/431