### PR TITLE
Add a GitHub Actions Workflow

### DIFF
--- a/.github/workflows/test-and-lint.yml
+++ b/.github/workflows/test-and-lint.yml
@@ -1,0 +1,27 @@
+name: test-and-lint
+on:
+  push:
+    branches: [ master, stable ]
+  pull_request:
+    branches: [ master, stable ]
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        # Support LTS versions based on https://nodejs.org/en/about/releases/
+        node-version: ['10', '12', '14']
+    steps:
+      - uses: actions/checkout@v2
+      - name: Use Node.js ${{ matrix.node-version }}
+        uses: actions/setup-node@v2
+        with:
+          node-version: ${{ matrix.node-version }}
+      - name: Install dependencies
+        run: npm install
+      - name: Compile TypeScript
+        run: tsc
+      - name: Run tests
+        run: npm test
+      - name: Run linter
+        run: npm run lint


### PR DESCRIPTION
This GitHub Action Workflow should replicate the continuous integration that .travis.yml/travis-ci.org performed. This is in regards to #1222.

If the project is happy with how this runs and after a little time, a new PR can be created to remove Travis CI to close the referenced issue. We could remove Travis CI now but there's no harm in running both for a bit to verify functionality.