### PR TITLE
Fix/improve bash snippet formatting

### DIFF
--- a/doc/contributing/building.rst
+++ b/doc/contributing/building.rst
@@ -27,7 +27,7 @@ Production
 
 .. CODE:: console
 
-   $ npm run build
+   $ npm run build:release
 
 This creates the minified production build in ``release/``.
 

--- a/doc/contributing/building.rst
+++ b/doc/contributing/building.rst
@@ -9,7 +9,7 @@ Building
 Development
 -----------
 
-.. CODE:: bash
+.. CODE:: console
 
    $ npm run dev
 
@@ -18,15 +18,14 @@ This will watch ``src/`` for changes and build ``remotestorage.js`` in the
 rs.js changes with an app, for example by creating a symlink to
 ``release/remotestorage.js``.
 
-This build includes [source
-maps](https://www.html5rocks.com/en/tutorials/developertools/sourcemaps/)
+This build includes `source maps <https://www.html5rocks.com/en/tutorials/developertools/sourcemaps/>`_
 directly, so you can easily place ``debugger`` statements in the code and step
 through the actual source code in your browser's debugger tool.
 
 Production
 ----------
 
-.. CODE:: bash
+.. CODE:: console
 
    $ npm run build
 

--- a/doc/contributing/docs.rst
+++ b/doc/contributing/docs.rst
@@ -1,3 +1,5 @@
+.. highlight:: console
+
 Documentation
 =============
 

--- a/doc/contributing/release-checklist.rst
+++ b/doc/contributing/release-checklist.rst
@@ -1,7 +1,7 @@
+.. highlight:: console
+
 Release checklist
 =================
-
-.. highlight:: bash
 
 * Build library and manually test all browsers you have access to, including
   mobile devices and private browsing mode
@@ -10,7 +10,7 @@ Release checklist
 
     * Collect and summarize changes using e.g.::
 
-         git log --no-merges <LAST RELEASE TAG>..HEAD
+         $ git log --no-merges <LAST RELEASE TAG>..HEAD
 
     * Add changes to `CHANGELOG.md`
     * Commit to Git
@@ -36,7 +36,7 @@ Release checklist
 
 * Publish to npm (https://www.npmjs.org/package/remotestoragejs)::
 
-     npm publish
+     $ npm publish
 
 * Update https://github.com/remotestorage/myfavoritedrinks to use new release
 

--- a/doc/contributing/testing.rst
+++ b/doc/contributing/testing.rst
@@ -9,14 +9,14 @@ test suites and `JSHint <http://jshint.com/about/>`_ for linting. Both are set
 as dev dependencies in ``package.json``, so after installing those via ``npm
 install``, you can use the following command to run everything at once:
 
-.. CODE:: bash
+.. CODE:: console
 
    $ npm run test
 
 Or you can use the Jaribu executable directly in order to run the suite for a
 single file:
 
-.. CODE:: bash
+.. CODE:: console
 
    $ ./node_modules/.bin/jaribu test/unit/cachinglayer-suite.js
 

--- a/doc/getting-started/how-to-add.rst
+++ b/doc/getting-started/how-to-add.rst
@@ -12,11 +12,11 @@ may also just download the release build `from GitHub
 The package is available on `npm <https://www.npmjs.com/>`_ as
 ``remotestoragejs`` and on `Bower <https://bower.io/>`_ as ``remotestorage``:
 
-.. code:: bash
+.. code:: console
 
    $ npm install remotestoragejs
 
-.. code:: bash
+.. code:: console
 
    $ bower install -S rs
 


### PR DESCRIPTION
The command snippets in the docs are currently marked as either `bash` or nothing (i.e. automatic formatting). However, there's a better way, which highlights the `$` prefix, as well as prevents it from being copied when selecting the entire line to copy and paste it.

Edit: selecting only the command itself, not including the '$` prefix, only works with the build on my local machine, but not in the RTD preview build so far. So maybe we'll have to wait for them to update their theme in production for this to work.