### PR TITLE
Allow to connect via URL

### DIFF
--- a/src/discover.ts
+++ b/src/discover.ts
@@ -18,7 +18,7 @@ let cachedInfo = {};
  * This function deals with the Webfinger lookup, discovering a connecting
  * user's storage details.
  *
- * @param {string} userAddress - user@host
+ * @param {string} userAddress - user@host or URL
  *
  * @returns {Promise} A promise for an object with the following properties.
  *          href - Storage base URL,

--- a/src/remotestorage.ts
+++ b/src/remotestorage.ts
@@ -327,14 +327,19 @@ class RemoteStorage {
    *    tokens in all requests later on. This is useful for example when using
    *    Kerberos and similar protocols.
    *
-   * @param {string} userAddress - The user address (user@host) to connect to.
+   * @param {string} userAddress - The user address (user@host) or URL to connect to.
    * @param {string} token       - (optional) A bearer token acquired beforehand
    */
   connect (userAddress: string, token?: string): void {
     this.setBackend('remotestorage');
-    if (userAddress.indexOf('@') < 0) {
-      this._emit('error', new RemoteStorage.DiscoveryError("User address doesn't contain an @."));
+    if (userAddress.indexOf('@') < 0 && !userAddress.match(/^(https?:\/\/)?[^\s\/$\.?#]+\.[^\s]*$/)) {
+      this._emit('error', new RemoteStorage.DiscoveryError("Not a valid user address or URL."));
       return;
+    }
+
+    // Prefix URL with https:// if it's missing
+    if (userAddress.indexOf('@') < 0 && !userAddress.match(/^https?:\/\//)) {
+      userAddress = `https://${userAddress}`;
     }
 
     if (globalContext.cordova) {

--- a/test/unit/remotestorage-suite.js
+++ b/test/unit/remotestorage-suite.js
@@ -246,12 +246,42 @@ define(['require', 'tv4', './build/eventhandling', './build/util'],
       },
 
       {
-        desc: "#connect throws unauthorized when userAddress doesn't contain an @",
+        desc: "#connect throws unauthorized when userAddress doesn't contain an @ or URL",
         run: function(env, test) {
           env.rs.on('error', function(e) {
             test.assert(e instanceof RemoteStorage.DiscoveryError, true);
           });
           env.rs.connect('somestring');
+        }
+      },
+
+      {
+        desc: "#connect accepts URLs for the userAddress",
+        run: function(env, test) {
+          env.rs.on('error', function(e) {
+            test.fail('URL userAddress was not accepted.');
+          });
+
+          env.rs.remote = new FakeRemote(false);
+          env.rs.remote.configure = function (options) {
+            test.assert(options.userAddress, 'https://personal.ho.st');
+          }
+          env.rs.connect('https://personal.ho.st');
+        }
+      },
+
+      {
+        desc: "#connect adds missing https:// to URLs",
+        run: function(env, test) {
+          env.rs.on('error', function(e) {
+            test.fail('URL userAddress was not accepted.');
+          });
+
+          env.rs.remote = new FakeRemote(false);
+          env.rs.remote.configure = function (options) {
+            test.assert(options.userAddress, 'https://personal.ho.st');
+          }
+          env.rs.connect('personal.ho.st');
         }
       },
 


### PR DESCRIPTION
Closes #1247

This change allows to connect using a URL. If the URL is missing the protocol, it's prefixed with "https://" before starting the Webfinger discovery.