### PR TITLE
Improve storeObject() documentation

### DIFF
--- a/doc/js-api/base-client.rst
+++ b/doc/js-api/base-client.rst
@@ -393,7 +393,7 @@ the change event handler, nor by chaining Promises. :func:`storeObject` or
 :func:`storeFile` must not be called until the next iteration of the JavaScript
 Task Queue, using for example `setTimeout()`_.
 
-If no algorithm exists, conflict resolution typically involves displaing local
+If no algorithm exists, conflict resolution typically involves displaying local
 and remote versions to the user, and having the user merge them, or choose
 which version to keep.
 

--- a/src/baseclient.ts
+++ b/src/baseclient.ts
@@ -236,6 +236,8 @@ class BaseClient {
    * See ``declareType()`` and :doc:`data types </data-modules/defining-data-types>`
    * for an explanation of types
    *
+   * For any given `path`, must not be called more frequently than once per second.
+   *
    * @param {string} typeAlias   - Unique type of this object within this module.
    * @param {string} path   - Path relative to the module root.
    * @param {object} object - A JavaScript object to be stored at the given


### PR DESCRIPTION
Notes that storeObject() mustn't be called more than 1/s. It's best to know this **before** writing code to save to RemoteStorage.