### PR TITLE
Improve validation of custom sync interval settings

### DIFF
--- a/src/remotestorage.ts
+++ b/src/remotestorage.ts
@@ -49,12 +49,12 @@ function emitUnauthorized(r) {
 }
 
 /**
-* Check if interval is valid: numeric and between 1000ms and 3600000ms
+* Check if interval is valid: numeric and between 2s and 1hr inclusive
 */
 function isValidInterval(interval: unknown): interval is number {
   return (typeof interval === 'number' &&
-          interval > 1000 &&
-          interval < 3600000);
+          interval >= 2000 &&
+          interval <= 3600000);
 }
 
 /**
@@ -715,7 +715,7 @@ class RemoteStorage {
   /**
    * Set the value of the sync interval when application is in the foreground
    *
-   * @param interval - Sync interval in milliseconds (between 1000 and 3600000)
+   * @param interval - Sync interval in milliseconds (between 2000 and 3600000 [1 hour])
    */
   setSyncInterval (interval: number): void {
     if (!isValidInterval(interval)) {
@@ -739,7 +739,7 @@ class RemoteStorage {
    * Set the value of the sync interval when the application is in the
    * background
    *
-   * @param interval - Sync interval in milliseconds (between 1000 and 3600000)
+   * @param interval - Sync interval in milliseconds (between 2000 and 3600000 [1 hour])
    */
   setBackgroundSyncInterval (interval: number): void {
     if (!isValidInterval(interval)) {

--- a/test/unit/sync-suite.js
+++ b/test/unit/sync-suite.js
@@ -165,8 +165,8 @@ define(['./build/util', 'require', 'test/helpers/mocks'], function(util, require
       {
         desc: "Update sync interval",
         run: function(env, test) {
-          env.rs.setSyncInterval(60000);
-          test.assert(env.rs.getSyncInterval(), 60000);
+          env.rs.setSyncInterval(2000);
+          test.assert(env.rs.getSyncInterval(), 2000);
         }
       },
 
@@ -183,6 +183,35 @@ define(['./build/util', 'require', 'test/helpers/mocks'], function(util, require
           }
         }
       },
+
+      {
+        desc: "Setting a sync interval too short throws an error",
+        run: function(env, test) {
+          test.assertAnd(env.rs.sync._tasks, {});
+          test.assertAnd(env.rs.sync._running, {});
+          try {
+            env.rs.setSyncInterval(1999);
+            test.result(false, "setSyncInterval() didn't fail");
+          } catch(e) {
+            test.result(true);
+          }
+        }
+      },
+
+      {
+        desc: "Setting a sync interval too long throws an error",
+        run: function(env, test) {
+          test.assertAnd(env.rs.sync._tasks, {});
+          test.assertAnd(env.rs.sync._running, {});
+          try {
+            env.rs.setSyncInterval(3600001);
+            test.result(false, "setSyncInterval() didn't fail");
+          } catch(e) {
+            test.result(true);
+          }
+        }
+      },
+
       {
         desc: "Sync calls doTasks, and goes to collectTasks only if necessary",
         run: function(env, test) {


### PR DESCRIPTION
The "principle of least surprise" suggests that the if the upper limit is "1 hour", you should be able to use 3600000, rather than 3599999.

Minimum sync interval is now 2s and sync interval range is now inclusive.