### PR TITLE
Fix Sphinx Documentation Build

### DIFF
--- a/doc/conf.py
+++ b/doc/conf.py
@@ -196,7 +196,7 @@ texinfo_documents = [
 #
 # Manually add custom Node.js/npm from conda to PATH
 python_executable_directory = Path(sys.executable).parent
-sys.path.insert(0, python_executable_directory)
+sys.path.insert(0, str(python_executable_directory))
 os.environ["PATH"] = f"{python_executable_directory}:{os.environ['PATH']}"
 # Verify Node.js version is correct
 os.system('node --version')


### PR DESCRIPTION
This resolves #1262.

Per this comment https://github.com/pypa/setuptools/issues/2548#issuecomment-771059348 and the Python docs https://docs.python.org/3/library/sys.html#sys.path, `sys.path` should only contain strings and not `Path` objects. Since we do not have dependencies frozen, a recent update to Sphinx broke the documentation build.