### PR TITLE
Improve sync events

### DIFF
--- a/src/sync.ts
+++ b/src/sync.ts
@@ -932,7 +932,7 @@ class Sync {
         log('[Sync] wireclient rejects its promise!', task.path, task.action, err);
         return this.handleResponse(task.path, task.action, { statusCode: 'offline' });
       })
-      .then(completed => {
+      .then(async (completed) => {
         this._finishedTasks.shift();
         delete this._timeStarted[task.path];
         delete this._running[task.path];
@@ -955,7 +955,7 @@ class Sync {
           return;
         }
 
-        this.collectTasks(false).then(() => {
+        await this.collectTasks(false).then(() => {
           // See if there are any more tasks that are not refresh tasks
           if (!this.hasTasks() || this.stopped) {
             log('[Sync] Sync is done! Reschedule?', Object.getOwnPropertyNames(this._tasks).length, this.stopped);

--- a/src/sync.ts
+++ b/src/sync.ts
@@ -914,7 +914,7 @@ class Sync {
       return;
     }
 
-    if (queueTask){
+    if (queueTask) {
       log("[Sync] queue finished task:", task.path);
       this._finishedTasks.push(task);
       if (this._finishedTasks.length > 1) {
@@ -946,7 +946,9 @@ class Sync {
           }
         }
 
-        this.rs._emit('sync-req-done');
+        this.rs._emit('sync-req-done', {
+          tasksRemaining: Object.keys(this._tasks).length
+        });
 
         if (this._finishedTasks.length > 0) {
           this.finishTask(this._finishedTasks[0], false);
@@ -959,7 +961,7 @@ class Sync {
             log('[Sync] Sync is done! Reschedule?', Object.getOwnPropertyNames(this._tasks).length, this.stopped);
             if (!this.done) {
               this.done = true;
-              this.rs._emit('sync-done');
+              this.rs._emit('sync-done', { completed: true });
             }
           } else {
             // Use a 10ms timeout to let the JavaScript runtime catch its breath
@@ -970,17 +972,23 @@ class Sync {
         });
       }, err => {
         log('[Sync] Error', err);
+
         this._finishedTasks.shift();
         delete this._timeStarted[task.path];
         delete this._running[task.path];
-        this.rs._emit('sync-req-done');
+
+        this.rs._emit('sync-req-done', {
+          tasksRemaining: Object.keys(this._tasks).length
+        });
+
         if (this._finishedTasks.length > 0) {
           this.finishTask(this._finishedTasks[0], false);
           return;
         }
+
         if (!this.done) {
           this.done = true;
-          this.rs._emit('sync-done');
+          this.rs._emit('sync-done', { completed: false });
         }
       });
   }

--- a/test/unit/sync.test.ts
+++ b/test/unit/sync.test.ts
@@ -1,5 +1,5 @@
 import 'mocha';
-import chai, { expect } from 'chai';
+import { expect } from 'chai';
 import sinon from 'sinon';
 import RemoteStorage from "../../src/remotestorage";
 import Sync from "../../src/sync";
@@ -26,7 +26,7 @@ describe("Sync", () => {
         "/example/one": {
           "action": "get",
           "path": "/example/one",
-          "promise": new Promise((resolve, reject) => {
+          "promise": new Promise(resolve => {
             resolve({
               "statusCode": 200,
               "body": "one",
@@ -38,18 +38,18 @@ describe("Sync", () => {
         "/example/two": {
           "action": "get",
           "path": "/example/two",
-          "promise": new Promise((resolve, reject) => {
+          "promise": new Promise(resolve => {
             resolve({ "statusCode": 500 });
           })
         }
-      }
+      };
       rs.sync._tasks = tasks;
-      rs.sync.doTasks = () => { return; }
+      rs.sync.doTasks = () => { return; };
     });
 
     afterEach(() => {
       rs.stopSync();
-    })
+    });
 
     describe("successfully completed", () => {
       it("emits 'sync-req-done' with the number of remaining tasks", async () => {
@@ -64,7 +64,7 @@ describe("Sync", () => {
 
       describe("last task", () => {
         beforeEach(() => {
-          rs.sync._tasks = { "/example/one": tasks["/example/one"] }
+          rs.sync._tasks = { "/example/one": tasks["/example/one"] };
         });
 
         it("marks the sync as done", async () => {

--- a/test/unit/sync.test.ts
+++ b/test/unit/sync.test.ts
@@ -1,0 +1,66 @@
+import 'mocha';
+import chai, {expect} from 'chai';
+import sinon from 'sinon';
+import RemoteStorage from "../../src/remotestorage";
+import Sync from "../../src/sync";
+import InMemoryStorage from "../../src/inmemorystorage";
+
+let rs, tasks;
+
+describe("Sync", () => {
+
+  before(() => {
+    rs = new RemoteStorage();
+    rs.local = new InMemoryStorage();
+    rs.sync = new Sync(rs);
+  });
+
+  describe("#finishTask", () => {
+    beforeEach(() => {
+      tasks = {
+        "/example/one": {
+          "action": "get",
+          "path": "/example/one",
+          "promise": new Promise((resolve, reject) => {
+            resolve({
+              "statusCode": 200,
+              "body": "one",
+              "contentType": "text/plain; charset=UTF-8",
+              "revision": "123456abcdef"
+            });
+          })
+        },
+        "/example/two": {
+          "action": "get",
+          "path": "/example/two",
+          "promise": new Promise((resolve, reject) => {
+            resolve({ "statusCode": 500 });
+          })
+        }
+      }
+      rs.sync._tasks = tasks;
+      rs.sync.doTasks = () => { return; }
+    });
+
+    describe("successfully completed", () => {
+      it("emits 'sync-req-done' with the number of remaining tasks", async () => {
+        const eventHandler = evt => { expect(evt.tasksRemaining).to.equal(1); }
+        rs.on('sync-req-done', eventHandler);
+        await rs.sync.finishTask(tasks["/example/one"], false);
+        rs.removeEventListener('sync-req-done', eventHandler);
+        rs.stopSync();
+      });
+    });
+
+    describe("failed to complete", () => {
+      it("emits 'sync-req-done' with the number of remaining tasks", async () => {
+        const eventHandler = evt => { expect(evt.tasksRemaining).to.equal(2); }
+        rs.on('sync-req-done', eventHandler);
+        await rs.sync.finishTask(tasks["/example/two"], false);
+        rs.removeEventListener('sync-req-done', eventHandler);
+        rs.stopSync();
+      });
+    });
+  });
+
+});

--- a/test/unit/sync.test.ts
+++ b/test/unit/sync.test.ts
@@ -1,5 +1,5 @@
 import 'mocha';
-import chai, {expect} from 'chai';
+import chai, { expect } from 'chai';
 import sinon from 'sinon';
 import RemoteStorage from "../../src/remotestorage";
 import Sync from "../../src/sync";
@@ -8,11 +8,16 @@ import InMemoryStorage from "../../src/inmemorystorage";
 let rs, tasks;
 
 describe("Sync", () => {
+  const sandbox = sinon.createSandbox();
 
-  before(() => {
+  beforeEach(() => {
     rs = new RemoteStorage();
     rs.local = new InMemoryStorage();
     rs.sync = new Sync(rs);
+  });
+
+  afterEach(() => {
+    sandbox.restore();
   });
 
   describe("#finishTask", () => {
@@ -42,23 +47,66 @@ describe("Sync", () => {
       rs.sync.doTasks = () => { return; }
     });
 
+    afterEach(() => {
+      rs.stopSync();
+    })
+
     describe("successfully completed", () => {
       it("emits 'sync-req-done' with the number of remaining tasks", async () => {
-        const eventHandler = evt => { expect(evt.tasksRemaining).to.equal(1); }
-        rs.on('sync-req-done', eventHandler);
+        const rsEmit = sinon.spy(rs, '_emit');
+
         await rs.sync.finishTask(tasks["/example/one"], false);
-        rs.removeEventListener('sync-req-done', eventHandler);
-        rs.stopSync();
+
+        expect(rsEmit.callCount).to.equal(1);
+        expect(rsEmit.getCall(0).args[0]).to.equal('sync-req-done');
+        expect(rsEmit.getCall(0).args[1]).to.have.property('tasksRemaining', 1);
+      });
+
+      describe("last task", () => {
+        beforeEach(() => {
+          rs.sync._tasks = { "/example/one": tasks["/example/one"] }
+        });
+
+        it("marks the sync as done", async () => {
+          await rs.sync.finishTask(tasks["/example/one"], false);
+          expect(rs.sync.done).to.be.true;
+        });
+
+        it("emits 'sync-done' with positive 'completed' status", async () => {
+          const rsEmit = sinon.spy(rs, '_emit');
+
+          await rs.sync.finishTask(tasks["/example/one"], false);
+
+          expect(rsEmit.callCount).to.equal(2);
+          expect(rsEmit.getCall(1).args[0]).to.equal('sync-done');
+          expect(rsEmit.getCall(1).args[1]).to.have.property('completed', true);
+        });
       });
     });
 
     describe("failed to complete", () => {
       it("emits 'sync-req-done' with the number of remaining tasks", async () => {
-        const eventHandler = evt => { expect(evt.tasksRemaining).to.equal(2); }
-        rs.on('sync-req-done', eventHandler);
+        const rsEmit = sinon.spy(rs, '_emit');
+
         await rs.sync.finishTask(tasks["/example/two"], false);
-        rs.removeEventListener('sync-req-done', eventHandler);
-        rs.stopSync();
+
+        expect(rsEmit.callCount).to.equal(3); // 'error', 'sync-req-done', 'sync-done'
+        expect(rsEmit.getCall(1).args[0]).to.equal('sync-req-done');
+        expect(rsEmit.getCall(1).args[1]).to.have.property('tasksRemaining', 2);
+      });
+
+      it("marks the sync as done", async () => {
+        await rs.sync.finishTask(tasks["/example/two"], false);
+        expect(rs.sync.done).to.be.true;
+      });
+
+      it("emits 'sync-done' with negative 'completed' status", async () => {
+        const rsEmit = sinon.spy(rs, '_emit');
+
+        await rs.sync.finishTask(tasks["/example/two"], false);
+
+        expect(rsEmit.getCall(2).args[0]).to.equal('sync-done');
+        expect(rsEmit.getCall(2).args[1]).to.have.property('completed', false);
       });
     });
   });


### PR DESCRIPTION
* Add "completed" status to `sync-done`
  A sync can be done with uncompleted tasks from errored requests. It will then continue during the next periodic sync, trying to fetch the errored items again. However, for UI integration it is useful to know whether the full sync process is completed or not, so it doesn't have to show sync finishing and re-starting several times throughout a long process with many items, which may involve a few attempts here and there.
* Add number of remaining tasks in queue to `sync-req-done`
  This is just an indicator of overall status, since the internal queue only ever holds 100 items at most. However, for UI integration, it can be useful to know if there's a larger queue left. For example to show a dedicated sync status, as opposed to hiding it in order to not inform the user about small, relatively immediate sync procedures.

