### PR TITLE
Automate website updates

### DIFF
--- a/.github/workflows/notify-website-repo.yml
+++ b/.github/workflows/notify-website-repo.yml
@@ -1,0 +1,17 @@
+name: Notify website repo
+
+on:
+  push:
+    branches:
+      - master
+
+jobs:
+  notify:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Repository Dispatch
+        uses: peter-evans/repository-dispatch@v2
+        with:
+          token: ${{ secrets.RS_DISPATCH_PAT }}
+          repository: remotestorage/website
+          event-type: rsjs-master-updated

--- a/.github/workflows/test-and-lint.yml
+++ b/.github/workflows/test-and-lint.yml
@@ -1,9 +1,11 @@
-name: test-and-lint
+name: Test and lint
+
 on:
   push:
     branches: [ master, stable ]
   pull_request:
     branches: [ master, stable ]
+
 jobs:
   build:
     name: node.js

--- a/docs/contributing/docs.md
+++ b/docs/contributing/docs.md
@@ -27,9 +27,12 @@ typedoc --watch
 
 ## Publishing
 
-The rs.js documentation on https://remotestorage.io/rs.js/docs/ is published from the [remotestorage/website](https://github.com/remotestorage/website/) repo. This repository is included as a submodule in the website repo, so that there is no duplication of content or builds.
+The rs.js documentation on https://remotestorage.io/rs.js/docs/ is
+published from the
+[remotestorage/website](https://github.com/remotestorage/website/)
+repo.
 
-This means that any merged rs.js docs changes currently require a manual update of the website repository in order to be visible in the public docs.
-
-> [!NOTE]
-> The process of updating the website automatically, whenever rs.js docs changes are merged, will be automated soon
+This repository is included as a submodule in the website repo to avoid
+duplication of content or builds. Whenever this repository's `master` branch is
+updated on GitHub, it will notify the website repo to update its submodule and
+trigger a new website build and deployment.

--- a/docs/contributing/docs.md
+++ b/docs/contributing/docs.md
@@ -3,23 +3,33 @@
 The documentation for remoteStorage.js comes from two different sources:
 
 1. Markdown documents in the `docs/` folder for normal pages
-2. TypeDoc comments in the source code, which are also rendered as Markdown pages when updating the website
+2. TypeDoc comments in the source code, which are also rendered as Markdown
+   pages when updating the website
 
-The pages are then transformed into a functional website using [VitePress](https://vitepress.dev/). Please refer to the VitePress documentation for available [Markdown extensions](https://vitepress.dev/guide/markdown), [configuring the sidebar menu](https://vitepress.dev/reference/default-theme-sidebar), and more.
+The pages are then transformed into a functional website using
+[VitePress](https://vitepress.dev/). Please refer to the VitePress
+documentation for available [Markdown
+extensions](https://vitepress.dev/guide/markdown), [configuring the sidebar
+menu](https://vitepress.dev/reference/default-theme-sidebar), and more.
 
 ## Contributing
 
-You can just edit any Markdown document or TypeDoc comment and propose the changes in a new pull request. No need to build the docs locally if you don't want to.
+You can just edit any Markdown document or TypeDoc comment and propose the
+changes in a new pull request. No need to build the docs locally if you don't
+want to.
 
 ## Local preview
 
-There is a local setup in this repository for previewing the rendered output. A live preview with automatic reloading upon changes can be started using this command:
+There is a local setup in this repository for previewing the rendered output. A
+live preview with automatic reloading upon changes can be started using this
+command:
 
 ```sh
 npm run docs:dev
 ```
 
-If you want to edit TypeDoc comments and have the changes appear in your local preview, then you also have to run this command:
+If you want to edit TypeDoc comments and have the changes appear in your local
+preview, then you also have to run this command:
 
 ```sh
 typedoc --watch

--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
     "dev": "webpack --mode=development -w",
     "postshrinkwrap": "if [ \"`uname`\" = \"Darwin\" ]; then sed -i '' -e 's/http:\\/\\//https:\\/\\//g' package-lock.json; else sed -i -e 's/http:\\/\\//https:\\/\\//g' package-lock.json; fi",
     "preversion": "npm test && npm run test:mocha && npm run lint:quiet && npm run build:js",
-    "version": "npm run build:release && git add release/",
+    "version": "npm run build:release && git add release/ && typedoc && git add docs/api/",
     "docs:dev": "vitepress dev docs",
     "docs:build": "vitepress build docs",
     "docs:preview": "vitepress preview docs"


### PR DESCRIPTION
This adds an Action to notify the website repo of updates to this repo's master branch, which should trigger a website build and deployment.

I haven't tested this yet, but in theory it should trigger this action that I pushed to the website repo already:

https://github.com/remotestorage/website/blob/master/.github/workflows/update-rsjs-submodule.yml

Maybe someone could have a quick look to spot any blunders, before we try this in production.

(There's also a change for building and committing the typedoc API docs upon release via `npm version`.)