### PR TITLE
Add Deno hints to the docs

### DIFF
--- a/docs/getting-started/how-to-add.md
+++ b/docs/getting-started/how-to-add.md
@@ -28,6 +28,10 @@ $ yarn add -D remotestoragejs
 ```sh [bun]
 $ bun add -D remotestoragejs
 ```
+
+```sh [deno]
+$ deno add npm:remotestoragejs
+```
 :::
 
 ## Examples

--- a/docs/nodejs.md
+++ b/docs/nodejs.md
@@ -74,6 +74,14 @@ want to consider as an option when writing non-browser applications.
   it may be necessary to set `global.fetch` with a polyfill such as
   [node-fetch](https://www.npmjs.com/package/node-fetch).
 
+::: tip
+You may also want to consider modern JavaScript/TypeScript runtimes other than
+Node.js, depending on your use case. With [Deno](https://deno.com/) for
+example, you have `localStorage` (but not `IndexedDB`) included, so it does in
+fact cache your data similar to how a browser would do it.
+:::
+
+
 ## Examples
 
 -   [hubot-remotestorage-logger](https://github.com/67P/hubot-remotestorage-logger),


### PR DESCRIPTION
Deno comes with `localStorage` (and TypeScript) included, so it's actually quite nice for RS-enabled CLI programs.