### PR TITLE
Broadcast change events to other browser tabs

### DIFF
--- a/test/unit/cachinglayer.test.mjs
+++ b/test/unit/cachinglayer.test.mjs
@@ -95,4 +95,26 @@ describe("CachingLayer", function() {
       });
     });
   });
+
+  describe("#_emitChangeEvents", function() {
+    it("broadcasts the change to other browser tabs", function(done) {
+      this.rs.local.broadcastChannel = {
+        postMessage: (change) => {
+          expect(change.newValue).to.equal("bar");
+          done();
+        }
+      };
+
+      this.rs.local._emitChangeEvents([
+        {
+          path: "/foo/bar",
+          origin: 'window',
+          oldValue: "foo",
+          newValue: "bar",
+          oldContentType: "text/plain",
+          newContentType: "text/plain"
+        }
+      ]);
+    });
+  });
 });


### PR DESCRIPTION
Simple, but amazing UX. You can't change tabs fast enough to see the changes being applied live. :tada: 

closes #1137
closes #566