### PR TITLE
Update servers link

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ remoteStorage-compatible storage account. We recommend
 local test server.
 
 You can also get an account with a hoster, or use another
-remoteStorage server implementation: [Servers](https://wiki.remotestorage.io/Servers).
+remoteStorage server implementation: [Servers](https://remotestorage.io/servers).
 
 ### Visual File Browser
 


### PR DESCRIPTION
The old wiki links seem to not redirect successfully because of a certificate issue, and ignoring the issue redirects to the front page.