### PR TITLE
Fix binary string body corruption during sync

### DIFF
--- a/src/wireclient.ts
+++ b/src/wireclient.ts
@@ -369,8 +369,11 @@ class WireClient extends RemoteBase implements Remote {
     // Convert binary strings to Uint8Array to prevent fetch() from UTF-8
     // encoding non-ASCII characters (code points 128+), which corrupts
     // binary data by expanding single bytes into multi-byte sequences.
-    // Only applies to non-text content types without an explicit charset.
-    if (typeof body === 'string' && !contentType.match(/^text\/|charset=/) && /[\u0080-\uffff]/.test(body)) {
+    // Skip for textual MIME types (text/*, JSON, XML, etc.) and when
+    // an explicit non-binary charset is set.
+    const isTextualType = /^text\/|[/+](json|xml|javascript|ecmascript)/i.test(contentType);
+    const hasNonBinaryCharset = /charset=/i.test(contentType) && !/charset=binary/i.test(contentType);
+    if (typeof body === 'string' && !isTextualType && !hasNonBinaryCharset && /[\u0080-\uffff]/.test(body)) {
       const buf = new Uint8Array(body.length);
       for (let i = 0; i < body.length; i++) {
         buf[i] = body.charCodeAt(i);

--- a/test/unit/wireclient.test.mjs
+++ b/test/unit/wireclient.test.mjs
@@ -585,6 +585,23 @@ describe('WireClient', () => {
       expect(call[1].body).to.equal('café');
     });
 
+    it('does not convert non-ASCII strings with application/json content type', async () => {
+      await connectedClient.put('/foo/bar', '{"name":"café"}', 'application/json');
+      const call = fetchMock.calls('putFileOK')[0];
+      expect(call[1].headers).to.have.property('Content-Type').which.equals('application/json');
+      expect(call[1].body).to.equal('{"name":"café"}');
+    });
+
+    it('converts binary string even when charset=binary is already set', async () => {
+      const binaryStr = String.fromCharCode(200, 201, 202);
+      await connectedClient.put('/foo/binary', binaryStr, 'application/octet-stream; charset=binary');
+      const call = fetchMock.calls('putBinary')[0];
+      expect(call[1].headers).to.have.property('Content-Type').which.equals('application/octet-stream; charset=binary');
+      const body = call[1].body;
+      expect(body).to.be.an.instanceOf(Uint8Array);
+      expect(body[0]).to.equal(200);
+    });
+
     it('adds binary charset for ArrayBuffer PUT', async () => {
       await connectedClient.put('/foo/binary', new ArrayBuffer(3), 'image/jpeg');
       const call = fetchMock.calls('putBinary')[0];


### PR DESCRIPTION
## Summary
- Convert string bodies with non-ASCII characters to `Uint8Array` in `WireClient.put()` before passing to `fetch()`, which otherwise UTF-8 encodes strings and corrupts binary data
- Adds `; charset=binary` content-type header for converted bodies

Closes #1355

## Test plan
- [x] New unit test verifies binary string `String.fromCharCode(200, 201, 202)` is converted to `Uint8Array` with correct byte values
- [x] New test verifies `charset=binary` is added to content type
- [x] All existing tests pass