### PR TITLE
Set up Release Drafter for automatic release note drafts

### DIFF
--- a/.github/release-drafter.yml
+++ b/.github/release-drafter.yml
@@ -1,0 +1,24 @@
+categories:
+  - title: "Features"
+    labels:
+      - "feature"
+  - title: "Improvements"
+    labels:
+      - "improvement"
+  - title: "Bug Fixes"
+    labels:
+      - "bug"
+  - title: "Dev Environment & CI"
+    label: "dev environment"
+version-resolver:
+  minor:
+    labels:
+      - "feature"
+  patch:
+    labels:
+      - "improvement"
+      - "bug"
+      - "dev environment"
+  default: patch
+template: |
+  $CHANGES

--- a/.github/release-drafter.yml
+++ b/.github/release-drafter.yml
@@ -9,7 +9,8 @@ categories:
     labels:
       - "bug"
   - title: "Dev Environment & CI"
-    label: "dev environment"
+    labels:
+      - "dev environment"
 version-resolver:
   minor:
     labels:

--- a/.github/workflows/release-drafter.yml
+++ b/.github/workflows/release-drafter.yml
@@ -1,0 +1,19 @@
+name: Release Drafter
+
+on:
+  push:
+    branches:
+      - master
+
+# Permissions for default token (secrets.GITHUB_TOKEN)
+permissions:
+  contents: write
+  pull-requests: read
+
+jobs:
+  update_release_draft:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: release-drafter/release-drafter@v7
+        with:
+          config-name: release-drafter.yml # the default, loads '.github/release-drafter.yml'


### PR DESCRIPTION
Does what it says in the title.

I though we had this running via GitHub app before (which has been deprecated), but there was no config in the repo. May have used the defaults before, not sure.