### PR TITLE
docs: clarify sync patterns for handling incoming changes

### DIFF
--- a/docs/getting-started/events.md
+++ b/docs/getting-started/events.md
@@ -29,5 +29,27 @@ and when they're emitted.
 Also see *change events* in the [BaseClient API][2] reference, which you can
 use to handle incoming data and changes from the remote storage server.
 
+## Change events vs. sync events
+
+remoteStorage.js has two different event systems that serve different purposes:
+
+**`change` events** (on [BaseClient][2]) fire once per item when data is
+created, updated, or deleted — whether from a local write, a remote sync, or
+another browser tab. These are the primary way to keep your UI in sync with
+data. See [Loading data](./loading-data) for patterns on using them.
+
+**`sync-done`** (on [RemoteStorage][1]) fires when a sync cycle completes.
+It is a lifecycle signal, not a data-change signal — it fires every cycle,
+including idle ones where nothing changed. It is useful as a batch boundary
+(e.g. "reload once after all incoming changes have been processed") but
+should not be used as the sole indicator that data has changed.
+
+::: tip
+Use `change` events to know *what* changed. Use `sync-done` to know *when
+the sync cycle finished*. See [Handling bulk incoming
+changes](./loading-data#handling-bulk-incoming-changes) for a pattern that
+combines both.
+:::
+
 [1]: ../api/remotestorage/classes/RemoteStorage.html
 [2]: ../api/baseclient/classes/BaseClient.html

--- a/docs/getting-started/loading-data.md
+++ b/docs/getting-started/loading-data.md
@@ -67,4 +67,52 @@ wait to check the remote storage for potential updates, set the optional `maxAge
 argument to `false`.
 :::
 
+## Handling bulk incoming changes
+
+During a sync cycle, the library emits a separate `change` event for each
+incoming item. If another device added 20 photos, your `change` handler fires
+20 times during that cycle.
+
+The most efficient approach is to handle each event individually — update a
+single item in your UI state rather than reloading the full collection:
+
+```js
+client.on('change', event => {
+  if (event.newValue) {
+    addOrUpdateItem(event.relativePath, event.newValue);
+  } else {
+    removeItem(event.relativePath);
+  }
+});
+```
+
+::: warning Avoid calling getAll() in a change handler
+Calling [getAll()][1] inside a `change` handler means rereading the entire local
+cache on every incoming item. During a bulk sync this causes redundant reads
+against a cache that is still being populated.
+:::
+
+If your app architecture requires reloading full collections (e.g. a reactive
+store that replaces the entire items object), you can use `change` events as a
+signal and defer the reload until the sync cycle completes:
+
+```js
+let hasChanges = false;
+
+client.on('change', () => {
+  hasChanges = true;
+});
+
+remoteStorage.on('sync-done', () => {
+  if (hasChanges) {
+    hasChanges = false;
+    reloadFromCache(); // single getAll() call per cycle
+  }
+});
+```
+
+Note that `sync-done` fires at the end of every sync cycle — including idle
+ones where nothing changed. The `hasChanges` flag ensures you only reload when
+data has actually been updated.
+
 [1]: ../api/baseclient/classes/BaseClient.html#getall


### PR DESCRIPTION
Adds guidance to the getting-started docs on how to efficiently handle bulk incoming changes during sync cycles.

**loading-data.md** — new section "Handling bulk incoming changes":
- Recommends per-item change handling as the most efficient approach
- Warns against calling `getAll()` inside a change handler
- Documents the change-flag + `sync-done` batching pattern for apps that need full collection reloads

**events.md** — new section "Change events vs. sync events":
- Clarifies that `change` events are for data changes, `sync-done` is a lifecycle signal
- Links to the batching pattern in loading-data.md

These additions are based on feedback from @raucao in #1366 and real-world usage in [inbox-rs](https://github.com/silverbucket/inbox-rs), where the distinction between these event types wasn't clear from existing docs.

Closes #1366