### PR TITLE
docs: clarify that local writes sync automatically

### DIFF
--- a/docs/getting-started/read-and-write-data.md
+++ b/docs/getting-started/read-and-write-data.md
@@ -11,12 +11,6 @@ connecting storage if it fits your use case. Any data written locally is
 automatically synced to the remote storage server when connecting an
 account.
 
-## Sync after writes
-
-When caching is enabled, `storeObject()`, `storeFile()`, and `remove()` save
-changes locally first and synchronize them with the remote server
-automatically. You usually do not need any extra sync call after writing data.
-
 ## Using BaseClient
 
 A [BaseClient][2] instance is the main endpoint for interacting with
@@ -69,6 +63,11 @@ client.storeObject('my-custom-type', path, { foo: 1, bar: 2 })
   .then(() => console.log('object saved'))
   .catch((err) => console.log(err));
 ```
+
+When caching is enabled, `storeFile()`, `storeObject()`, and `remove()` save
+changes locally first and synchronize them with the remote server
+automatically. In most apps, you do not need to trigger anything extra after
+writing data.
 
 [1]: ../api/remotestorage/classes/RemoteStorage
 [2]: ../api/baseclient/classes/BaseClient

--- a/docs/getting-started/read-and-write-data.md
+++ b/docs/getting-started/read-and-write-data.md
@@ -64,10 +64,12 @@ client.storeObject('my-custom-type', path, { foo: 1, bar: 2 })
   .catch((err) => console.log(err));
 ```
 
+::: tip
 When caching is enabled, `storeFile()`, `storeObject()`, and `remove()` save
 changes locally first and synchronize them with the remote server
 automatically. In most apps, you do not need to trigger anything extra after
 writing data.
+:::
 
 [1]: ../api/remotestorage/classes/RemoteStorage
 [2]: ../api/baseclient/classes/BaseClient

--- a/docs/getting-started/read-and-write-data.md
+++ b/docs/getting-started/read-and-write-data.md
@@ -13,16 +13,9 @@ account.
 
 ## Sync after writes
 
-When caching is enabled, local writes are automatically queued for sync to the
-remote server. You do not need to call `startSync()` after calling
-`storeObject()`, `storeFile()`, or `remove()` — the library handles pushing
-local changes during the next sync cycle.
-
-::: tip
-`startSync()` is for manually triggering a check for _remote_ changes (e.g. a
-user-facing "sync now" button, or when returning to a tab after it was in the
-background). It is not needed to push local writes.
-:::
+When caching is enabled, `storeObject()`, `storeFile()`, and `remove()` save
+changes locally first and synchronize them with the remote server
+automatically. You usually do not need any extra sync call after writing data.
 
 ## Using BaseClient
 

--- a/docs/getting-started/read-and-write-data.md
+++ b/docs/getting-started/read-and-write-data.md
@@ -11,6 +11,19 @@ connecting storage if it fits your use case. Any data written locally is
 automatically synced to the remote storage server when connecting an
 account.
 
+## Sync after writes
+
+When caching is enabled, local writes are automatically queued for sync to the
+remote server. You do not need to call `startSync()` after calling
+`storeObject()`, `storeFile()`, or `remove()` — the library handles pushing
+local changes during the next sync cycle.
+
+::: tip
+`startSync()` is for manually triggering a check for _remote_ changes (e.g. a
+user-facing "sync now" button, or when returning to a tab after it was in the
+background). It is not needed to push local writes.
+:::
+
 ## Using BaseClient
 
 A [BaseClient][2] instance is the main endpoint for interacting with


### PR DESCRIPTION
Clarifies the default write behavior in the read-and-write-data getting-started guide.

This update now keeps the note next to the write examples instead of introducing a separate sync section early in the page. It clarifies that, when caching is enabled, `storeObject()`, `storeFile()`, and `remove()` save locally first and synchronize automatically, so applications usually do not need to trigger anything extra after a write.

This intentionally does not document `startSync()` in Getting Started; manual sync belongs in the API/reference docs.

Closes #1367
