### PR TITLE
Fix occasional unmatched requests in Dropbox suite

### DIFF
--- a/test/unit/dropbox.test.mjs
+++ b/test/unit/dropbox.test.mjs
@@ -51,6 +51,10 @@ describe('Dropbox backend', () => {
     rs = new RemoteStorage();
     rs.setApiKeys({dropbox: CLIENT_ID});   // an app would do this
 
+    // Prevent the background sync engine and fetchDelta from starting on 'connected'
+    rs.stopSync();
+    rs._handlers['connected'] = [];
+
     dropbox = rs.dropbox;
     dropbox.configure({
       userAddress: USER_ADDRESS,


### PR DESCRIPTION
Prevents unwanted background sync in Dropbox suite which may result in the suite completely successfully, but not hanging on exit (due to an unresolved auth request).