### PR TITLE
Updates CI to test under Node v22 & v24

### DIFF
--- a/.github/workflows/test-and-lint.yml
+++ b/.github/workflows/test-and-lint.yml
@@ -14,7 +14,7 @@ jobs:
     strategy:
       matrix:
         # Support LTS versions based on https://nodejs.org/en/about/releases/
-        node-version: ['18', '20', '22', '24']
+        node-version: ['20', '22', '24']
       fail-fast: false
     steps:
       - uses: actions/checkout@v6.0.2

--- a/.github/workflows/test-and-lint.yml
+++ b/.github/workflows/test-and-lint.yml
@@ -14,16 +14,17 @@ jobs:
     strategy:
       matrix:
         # Support LTS versions based on https://nodejs.org/en/about/releases/
-        node-version: ['18', '20']
+        node-version: ['18', '20', '22', '24']
+      fail-fast: false
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6.0.2
       - name: Use Node.js ${{ matrix.node-version }}
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6.3.0
         with:
           node-version: ${{ matrix.node-version }}
       - name: Install dependencies
         run: npm ci
-      - name: Run jaribu tests   # These must be replaced before we can use Node v18 in CI
+      - name: Run jaribu tests
         run: npm test
       - name: Run mocha tests
         run: npm run test:mocha -- --exit


### PR DESCRIPTION
Why: so we're warned of incompatibilities while we have plenty of time to fix them