### PR TITLE
Fix authorize hash cleanup for non-OAuth fragments

### DIFF
--- a/src/authorize.ts
+++ b/src/authorize.ts
@@ -47,6 +47,15 @@ export interface AuthorizeOptions {
 // This is set in _rs_init and needed for removal in _rs_cleanup
 let onFeaturesLoaded: EventHandler;
 
+function hasAuthCallbackParams (params: AuthResult): boolean {
+  return typeof params.access_token === 'string' ||
+    typeof params.code === 'string' ||
+    typeof params.error === 'string' ||
+    typeof params.remotestorage === 'string' ||
+    typeof params.state === 'string' ||
+    typeof params.rsDiscovery === 'object';
+}
+
 function extractParams (url?: string): AuthResult {
   // FF already decodes the URL fragment in document.location.hash, so use this instead:
   // eslint-disable-next-line
@@ -270,9 +279,10 @@ export class Authorize {
 
   static _rs_init = function (remoteStorage: RemoteStorage): void {
     const params = extractParams();
+    const hasCallbackParams = hasAuthCallbackParams(params);
     let location: Location;
 
-    if (params) {
+    if (hasCallbackParams) {
       location = Authorize.getLocation();
       location.hash = '';
     }
@@ -281,7 +291,7 @@ export class Authorize {
     onFeaturesLoaded = function(): void {
       let authParamsUsed = false;
 
-      if (!params) {
+      if (!hasCallbackParams) {
         remoteStorage.remote.stopWaitingForToken();
         return;
       }

--- a/src/authorize.ts
+++ b/src/authorize.ts
@@ -52,7 +52,6 @@ function hasAuthCallbackParams (params: AuthResult): boolean {
     typeof params.code === 'string' ||
     typeof params.error === 'string' ||
     typeof params.remotestorage === 'string' ||
-    typeof params.state === 'string' ||
     typeof params.rsDiscovery === 'object';
 }
 

--- a/test/unit/authorize-suite.js
+++ b/test/unit/authorize-suite.js
@@ -150,9 +150,18 @@ define([ 'require', './build/authorize', './build/unauthorized-error', 'test/hel
       },
 
       {
-        desc: "_rs_init removes params from the fragment",
+        desc: "_rs_init preserves fragments that are not OAuth callbacks",
         run: function(env, test) {
           document.location.href = 'http://foo/bar#foo=bar';
+          env.Authorize._rs_init(new RemoteStorage());
+          test.assert(env.Authorize.getLocation().href, 'http://foo/bar#foo=bar');
+        }
+      },
+
+      {
+        desc: "_rs_init removes OAuth callback params from the fragment",
+        run: function(env, test) {
+          document.location.href = 'http://foo/bar#access_token=my-token&state=foo';
           env.Authorize._rs_init(new RemoteStorage());
           test.assert(env.Authorize.getLocation().hash, '');
         }

--- a/test/unit/authorize.test.mjs
+++ b/test/unit/authorize.test.mjs
@@ -44,6 +44,21 @@ class MockRemote extends RemoteBase {
   }
 }
 
+function createStorage(remote) {
+  return {
+    _handlers: {
+      'features-loaded': []
+    },
+    remote,
+    on(eventName, handler) {
+      this._handlers[eventName].push(handler);
+    },
+    removeEventListener(eventName, handler) {
+      this._handlers[eventName] = this._handlers[eventName].filter((item) => item !== handler);
+    }
+  };
+}
+
 locationFactory('https://foo/bar');
 globalThis.localStorageAvailable = localStorageAvailable;
 globalThis["sessionStorage"] = sessionStorage;
@@ -111,6 +126,53 @@ describe("Authorize", () => {
   });
 
   describe("'features-loaded' handler", () => {
+    it("preserves hash routes that are not OAuth callbacks", () => {
+      const mockRemote = new MockRemote({});
+      const stopWaitingForTokenSpy = sinon.spy();
+      mockRemote.stopWaitingForToken = stopWaitingForTokenSpy;
+      const rs = createStorage(mockRemote);
+      rs.remote = mockRemote;
+      document.location.href = 'https://example.com/#/todos';
+
+      Authorize._rs_init(rs);
+
+      expect(document.location.hash).to.equal('#/todos');
+
+      rs._handlers['features-loaded'][0]();
+
+      expect(stopWaitingForTokenSpy.calledOnce).to.equal(true);
+      expect(document.location.hash).to.equal('#/todos');
+    });
+
+    it("clears OAuth callback params from the hash during init", () => {
+      const mockRemote = new MockRemote({});
+      const rs = createStorage(mockRemote);
+      rs.remote = mockRemote;
+      document.location.href = 'https://example.com/#access_token=foo&state=bar';
+
+      Authorize._rs_init(rs);
+
+      expect(document.location.hash).to.equal('');
+    });
+
+    it("ignores non-auth hash params that happen to contain an equals sign", () => {
+      const mockRemote = new MockRemote({});
+      const stopWaitingForTokenSpy = sinon.spy();
+      mockRemote.stopWaitingForToken = stopWaitingForTokenSpy;
+      const rs = createStorage(mockRemote);
+      rs.remote = mockRemote;
+      document.location.href = 'https://example.com/#foo=bar';
+
+      Authorize._rs_init(rs);
+
+      expect(document.location.hash).to.equal('#foo=bar');
+
+      rs._handlers['features-loaded'][0]();
+
+      expect(stopWaitingForTokenSpy.calledOnce).to.equal(true);
+      expect(document.location.hash).to.equal('#foo=bar');
+    });
+
     it("when it sees a code but no code verifier, doesn't call remote.configure()", async () => {
       const rs = new RemoteStorage();
       const mockRemote = new MockRemote(rs);


### PR DESCRIPTION
## Summary
- limit authorize hash cleanup to actual remoteStorage OAuth callback parameters
- preserve SPA and other application hashes that are unrelated to OAuth
- add Mocha and legacy Jaribu regression coverage for both callback and non-callback fragments

## Root cause
`Authorize._rs_init` cleared `location.hash` whenever `extractParams()` returned a truthy value. Since `extractParams()` always returns an object, non-OAuth fragments like `#/todos` and `#foo=bar` were being wiped during construction.

## Impact
Applications using hash-based routing no longer lose their current route when `RemoteStorage` is constructed, while real OAuth callback fragments are still cleaned up as before.

Closes https://github.com/remotestorage/remotestorage.js/issues/1373 and https://github.com/remotestorage/remotestorage.js/issues/1180
