### PR TITLE
Fix stale caching activation handler

### DIFF
--- a/src/caching.ts
+++ b/src/caching.ts
@@ -141,6 +141,16 @@ export class Caching {
   }
 
   /**
+   * Reset activation state for sync lifecycle cleanup.
+   *
+   * @internal
+   */
+  resetActivationHandler (): void {
+    this.activateHandler = undefined;
+    this.pendingActivations = [];
+  }
+
+  /**
    * Retrieve caching setting for a given path, or its next parent
    * with a caching strategy set.
    *

--- a/src/sync.ts
+++ b/src/sync.ts
@@ -1208,6 +1208,7 @@ export class Sync {
     remoteStorage.stopSync();
     remoteStorage.removeEventListener('ready', setupSync);
     remoteStorage.removeEventListener('connected', syncOnConnect);
+    remoteStorage.caching.resetActivationHandler();
 
     remoteStorage.sync = undefined;
     delete remoteStorage.sync;

--- a/test/unit/sync.test.mjs
+++ b/test/unit/sync.test.mjs
@@ -81,6 +81,13 @@ describe("Sync", function() {
       Sync._rs_cleanup(this.rs);
       expect(typeof this.rs.sync).to.equal("undefined");
     });
+
+    it("clears the caching activation handler", function() {
+      Sync._rs_cleanup(this.rs);
+      this.rs.caching.enable("/foo/");
+      this.rs.sync = new Sync(this.rs);
+      expect(this.rs.sync._tasks).to.have.property("/foo/");
+    });
   });
 
   describe("#getParentPath", function() {


### PR DESCRIPTION
## Summary
- clear caching activation state when Sync is cleaned up
- preserve pending ALL activations for the next Sync instance after disconnect/reconnect
- add a regression test for activations queued after cleanup

Fixes #1375
