### PR TITLE
Fix IndexedDB recovery for missing stores

### DIFF
--- a/src/indexeddb.ts
+++ b/src/indexeddb.ts
@@ -329,14 +329,15 @@ class IndexedDB extends CachingLayer {
 
         log("[IndexedDB] Upgrade: from ", event.oldVersion, " to ", event.newVersion);
 
-        if (event.oldVersion !== 1) {
+        if (!db.objectStoreNames.contains('nodes')) {
           log("[IndexedDB] Creating object store: nodes");
           db.createObjectStore('nodes', {keyPath: 'path'});
         }
 
-        log("[IndexedDB] Creating object store: changes");
-
-        db.createObjectStore('changes', {keyPath: 'path'});
+        if (!db.objectStoreNames.contains('changes')) {
+          log("[IndexedDB] Creating object store: changes");
+          db.createObjectStore('changes', {keyPath: 'path'});
+        }
       };
 
       req.onsuccess = function () {
@@ -346,6 +347,7 @@ class IndexedDB extends CachingLayer {
         const db = req.result;
         if (!db.objectStoreNames.contains('nodes') || !db.objectStoreNames.contains('changes')) {
           log("[IndexedDB] Missing object store. Resetting the database.");
+          db.close();
           IndexedDB.clean(name, function () {
             IndexedDB.open(name, callback);
           });
@@ -371,6 +373,10 @@ class IndexedDB extends CachingLayer {
    */
   static clean (databaseName: string, callback: () => void) {
     const req = indexedDB.deleteDatabase(databaseName);
+
+    req.onblocked = function (evt) {
+      console.warn(`Deleting IndexedDB database "${databaseName}" is blocked by another open connection`, evt);
+    };
 
     req.onsuccess = function () {
       log(`[IndexedDB] Deleted database "${databaseName}"`);

--- a/test/unit/indexeddb.test.mjs
+++ b/test/unit/indexeddb.test.mjs
@@ -1,0 +1,88 @@
+import "mocha";
+import { expect } from "chai";
+import sinon from "sinon";
+
+import IndexedDB from "../../build/indexeddb.js";
+
+function createObjectStoreNames(stores) {
+  return {
+    contains(name) {
+      return stores.has(name);
+    }
+  };
+}
+
+describe("IndexedDB", () => {
+  let originalIndexedDB;
+
+  beforeEach(() => {
+    originalIndexedDB = globalThis.indexedDB;
+  });
+
+  afterEach(() => {
+    globalThis.indexedDB = originalIndexedDB;
+    sinon.restore();
+  });
+
+  describe(".open", () => {
+    it("creates missing object stores during upgrades regardless of old version", (done) => {
+      const stores = new Set();
+      const db = {
+        objectStoreNames: createObjectStoreNames(stores),
+        createObjectStore(name) {
+          stores.add(name);
+        }
+      };
+      const request = { result: db };
+
+      globalThis.indexedDB = {
+        open() {
+          return request;
+        }
+      };
+
+      IndexedDB.open("remotestorage", (err, openedDb) => {
+        expect(err).to.equal(null);
+        expect(openedDb).to.equal(db);
+        expect(stores.has("nodes")).to.equal(true);
+        expect(stores.has("changes")).to.equal(true);
+        done();
+      });
+
+      request.onupgradeneeded({
+        oldVersion: 1,
+        newVersion: 2
+      });
+      request.onsuccess();
+    });
+
+    it("closes a database with missing object stores before deleting it", () => {
+      const close = sinon.spy();
+      const stores = new Set(["changes"]);
+      const db = {
+        objectStoreNames: createObjectStoreNames(stores),
+        close
+      };
+      const openRequest = { result: db };
+      const deleteRequest = {};
+
+      globalThis.indexedDB = {
+        open() {
+          return openRequest;
+        },
+
+        deleteDatabase() {
+          expect(close.calledOnce).to.equal(true);
+          return deleteRequest;
+        }
+      };
+
+      IndexedDB.open("remotestorage", () => {});
+
+      openRequest.onsuccess();
+
+      expect(close.calledOnce).to.equal(true);
+      expect(deleteRequest.onblocked).to.be.a("function");
+    });
+  });
+});


### PR DESCRIPTION
## Summary

- create missing IndexedDB object stores based on the actual schema during upgrades
- close the opened database connection before deleting a corrupt schema
- add coverage for empty v1 upgrade recovery and blocked cleanup visibility

Fixes #1376.
