### PR TITLE
Stop emitting non-standard "; charset=binary" suffix

### DIFF
--- a/src/baseclient.ts
+++ b/src/baseclient.ts
@@ -300,12 +300,12 @@ export class BaseClient {
    *     "screenshot-20170902-1913.png": {
    *       "ETag": "6749fcb9eef3f9e46bb537ed020aeece",
    *       "Content-Length": 53698,
-   *       "Content-Type": "image/png;charset=binary"
+   *       "Content-Type": "image/png"
    *     },
    *     "screenshot-20170823-0142.png": {
    *       "ETag": "92ab84792ef3f9e46bb537edac9bc3a1",
    *       "Content-Length": 412401,
-   *       "Content-Type": "image/png;charset=binary"
+   *       "Content-Type": "image/png"
    *     }
    *   }
    * }

--- a/src/dropbox.ts
+++ b/src/dropbox.ts
@@ -7,6 +7,7 @@ import {
   applyMixins,
   isFolder,
   shouldBeTreatedAsBinary,
+  stripLegacyCharsetBinary,
   getJSONFromLocalStorage,
   getTextFromArrayBuffer,
   localStorageAvailable,
@@ -453,7 +454,7 @@ class Dropbox extends RemoteBase implements Remote {
         return {
           statusCode: status,
           body: body,
-          contentType: mime,
+          contentType: stripLegacyCharsetBinary(mime),
           revision: rev
         };
       });

--- a/src/dropbox.ts
+++ b/src/dropbox.ts
@@ -494,10 +494,6 @@ class Dropbox extends RemoteBase implements Remote {
       return {statusCode: 412, revision: savedRev};
     }
 
-    if ((!contentType.match(/charset=/)) && isBinaryData(body)) {
-      contentType += '; charset=binary';
-    }
-
     if (body.length > 150 * 1024 * 1024) {
       //https://www.dropbox.com/developers/core/docs#chunked-upload
       throw new Error("Cannot upload file larger than 150MB");

--- a/src/googledrive.ts
+++ b/src/googledrive.ts
@@ -5,6 +5,7 @@ import {
   isFolder,
   cleanPath,
   shouldBeTreatedAsBinary,
+  stripLegacyCharsetBinary,
   getJSONFromLocalStorage,
   getTextFromArrayBuffer,
   localStorageAvailable
@@ -494,7 +495,7 @@ class GoogleDrive extends RemoteBase implements Remote {
             return {
               statusCode: 200,
               body: body,
-              contentType: meta.mimeType,
+              contentType: stripLegacyCharsetBinary(meta.mimeType),
               revision: etagWithoutQuotes
             };
           });

--- a/src/util.ts
+++ b/src/util.ts
@@ -213,6 +213,10 @@ export const getJSONFromLocalStorage = (key: string): { [key: string]: any } => 
  * @returns {boolean}
  */
 export const shouldBeTreatedAsBinary = (content: string | ArrayBuffer, mimeType: string): boolean => {
+  // The `charset=binary` branch is kept for backward compatibility: files uploaded
+  // with a release <=2.0.0-beta.9 carry that non-standard suffix in their stored
+  // Content-Type. New uploads no longer emit it; the control-char heuristic below
+  // handles them.
   // eslint-disable-next-line no-control-regex
   return !!((mimeType && mimeType.match(/charset=binary/)) || /[\x00-\x08\x0E-\x1F\uFFFD]/.test(content as string));
 };

--- a/src/util.ts
+++ b/src/util.ts
@@ -222,6 +222,27 @@ export const shouldBeTreatedAsBinary = (content: string | ArrayBuffer, mimeType:
 };
 
 /**
+ * Strip the legacy `; charset=binary` parameter from a Content-Type.
+ *
+ * Releases <=2.0.0-beta.9 appended this non-standard parameter to all binary
+ * PUTs, so files written back then still carry it in their stored Content-Type
+ * forever. We sanitize on read so callers never see it: some browsers refuse
+ * to render an `<img>` whose Blob type carries the suffix.
+ *
+ * Only the `charset=binary` parameter is removed; legitimate parameters like
+ * `charset=UTF-8` on `text/html` are preserved.
+ *
+ * @param {string} mimeType - The raw Content-Type as returned by the server.
+ * @returns {string} The Content-Type with any `; charset=binary` removed.
+ */
+export const stripLegacyCharsetBinary = (mimeType: string | null): string | null => {
+  if (!mimeType) {
+    return mimeType;
+  }
+  return mimeType.replace(/\s*;\s*charset=binary\b/i, '');
+};
+
+/**
  * Read data from an ArrayBuffer and return it as a string
  * @param {ArrayBuffer} arrayBuffer
  * @param {string} encoding

--- a/src/wireclient.ts
+++ b/src/wireclient.ts
@@ -44,7 +44,7 @@ import {
   localStorageAvailable,
   shouldBeTreatedAsBinary
 } from './util';
-import {requestWithTimeout, isArrayBufferView} from "./requests";
+import {requestWithTimeout} from "./requests";
 import {Remote, RemoteBase, RemoteResponse, RemoteSettings} from "./remote";
 
 let hasLocalStorage;
@@ -365,9 +365,6 @@ class WireClient extends RemoteBase implements Remote {
   put (path: string, body: XMLHttpRequestBodyInit, contentType: string, options: { ifMatch?: string; ifNoneMatch?: string } = {}): Promise<RemoteResponse> {
     if (!this.connected) {
       return Promise.reject('not connected (path: ' + path + ')');
-    }
-    if ((!contentType.match(/charset=/)) && (body instanceof ArrayBuffer || isArrayBufferView(body))) {
-      contentType += '; charset=binary';
     }
     const headers = {'Content-Type': contentType};
     if (this.supportsRevs) {

--- a/src/wireclient.ts
+++ b/src/wireclient.ts
@@ -42,7 +42,8 @@ import {
   getTextFromArrayBuffer,
   isFolder,
   localStorageAvailable,
-  shouldBeTreatedAsBinary
+  shouldBeTreatedAsBinary,
+  stripLegacyCharsetBinary
 } from './util';
 import {requestWithTimeout} from "./requests";
 import {Remote, RemoteBase, RemoteResponse, RemoteSettings} from "./remote";
@@ -214,7 +215,7 @@ class WireClient extends RemoteBase implements Remote {
           return Promise.resolve({
             statusCode: response.status,
             body: response.response,
-            contentType: mimeType,
+            contentType: stripLegacyCharsetBinary(mimeType),
             revision: revision
           });
         } else {
@@ -224,7 +225,7 @@ class WireClient extends RemoteBase implements Remote {
               return Promise.resolve({
                 statusCode: response.status,
                 body: textContent,
-                contentType: mimeType,
+                contentType: stripLegacyCharsetBinary(mimeType),
                 revision: revision
               });
             });

--- a/test/unit/node-wireclient-suite.js
+++ b/test/unit/node-wireclient-suite.js
@@ -165,7 +165,7 @@ define(['./build/wireclient', './build/remotestorage'], function (WireClient, Re
             iAmA: 'ArrayBufferMock',
             content: 'response content'
           });
-          test.assert(r.contentType, 'image/png; charset=binary');
+          test.assert(r.contentType, 'image/png');
         }, function (err) {
           test.result(false, err);
         });

--- a/test/unit/wireclient.test.mjs
+++ b/test/unit/wireclient.test.mjs
@@ -567,13 +567,13 @@ describe('WireClient', () => {
       expect(call[1].headers).to.have.property('Content-Type').which.equals('text/html; charset=UTF-8');
     });
 
-    it('adds binary charset for ArrayBuffer PUT', async () => {
+    it('does not add charset for ArrayBuffer PUT', async () => {
       await connectedClient.put('/foo/binary', new ArrayBuffer(3), 'image/jpeg');
       const call = fetchMock.calls('putBinary')[0];
-      expect(call[1].headers).to.have.property('Content-Type').which.equals('image/jpeg; charset=binary');
+      expect(call[1].headers).to.have.property('Content-Type').which.equals('image/jpeg');
     });
 
-    it('does not add second binary charset for ArrayBuffer PUT', async () => {
+    it('preserves caller-supplied charset for ArrayBuffer PUT', async () => {
       await connectedClient.put('/foo/binary', new ArrayBuffer(3), 'image/jpeg; charset=custom');
       const call = fetchMock.calls('putBinary')[0];
       expect(call[1].headers).to.have.property('Content-Type').which.equals('image/jpeg; charset=custom');

--- a/test/unit/wireclient.test.mjs
+++ b/test/unit/wireclient.test.mjs
@@ -321,17 +321,27 @@ describe('WireClient', () => {
       expect(res.body).to.equal('{"foo": "bar"}');
     });
 
-    it('returns raw response body when charset set to "binary"', async () => {
+    it('returns raw response body and strips legacy charset=binary suffix from contentType', async () => {
       fetchMock.mock(`${BASE_URI}/foo/binary`, {
         status: 200, body: 'something',
         headers: { 'Content-Type': 'application/octet-stream; charset=binary' }
       });
       const res = await connectedClient.get('/foo/binary');
       expect(res.statusCode).to.equal(200);
-      expect(res.contentType).to.equal('application/octet-stream; charset=binary');
+      expect(res.contentType).to.equal('application/octet-stream');
       expect(res.body).to.be.a('ArrayBuffer');
       const text = new TextDecoder('utf-8').decode(new Uint8Array(res.body));
       expect(text).to.equal('something');
+    });
+
+    it('preserves legitimate charset parameters in contentType', async () => {
+      fetchMock.mock(`${BASE_URI}/foo/text`, {
+        status: 200, body: 'hello',
+        headers: { 'Content-Type': 'text/html; charset=UTF-8' }
+      });
+      const res = await connectedClient.get('/foo/text');
+      expect(res.statusCode).to.equal(200);
+      expect(res.contentType).to.equal('text/html; charset=UTF-8');
     });
 
     it('returns text when content type missing and body only contains printable characters', async () => {


### PR DESCRIPTION
## Summary

Closes #1379.

`WireClient.put` and `Dropbox.put` append `; charset=binary` to the `Content-Type` header for ArrayBuffer / binary uploads. The string `binary` is not a registered IANA character set (RFC 6657), and the suffix has no effect on transport — XHR/fetch sends the body bytes verbatim regardless of the `charset=` parameter.

The suffix is sticky: servers (5apps, Armadietto, anyone storing the request `Content-Type` verbatim) write it into stored metadata and echo it back on GET. Some browsers — Chrome among them — refuse to render an `<img>` whose `Blob` type carries the suffix, producing a valid-looking `blob:` URL that never paints. Apps that pass `getFile()`'s `contentType` straight to a `Blob` constructor hit this.

## Approach

Two commits, two halves of the fix:

### 1. Stop emitting the suffix

| File | Change |
|---|---|
| `src/wireclient.ts` | Drop the suffix-append in `put()` (and the now-orphaned `isArrayBufferView` import). |
| `src/dropbox.ts` | Drop the matching suffix-append in `put()`. |
| `src/util.ts` | Keep the `charset=binary` branch in `shouldBeTreatedAsBinary` with a comment explaining it's there for backward compat with files uploaded by `<=2.0.0-beta.9`. The existing control-char heuristic handles new uploads. |
| `src/baseclient.ts` | Update example folder listings in the JSDoc to show clean `Content-Type` values. |
| `test/unit/wireclient.test.mjs` | Rename the two PUT charset tests to verify the new behavior (no suffix added; caller-supplied charset preserved). |

### 2. Strip the suffix on the read side too

Stops the suffix from leaking through `getFile().contentType` for files that already exist on servers with the legacy shape baked into their stored metadata. Without this half, apps would still see broken `<img>` rendering for old files even after upgrading to the fixed library version.

| File | Change |
|---|---|
| `src/util.ts` | Add `stripLegacyCharsetBinary` helper. Removes only the `; charset=binary` parameter — legitimate ones like `charset=UTF-8` on `text/html` are preserved. |
| `src/wireclient.ts`, `src/dropbox.ts`, `src/googledrive.ts` | Apply the strip at the response boundary in each remote's GET handler. Internal binary-vs-text detection still uses the original (pre-strip) header so `shouldBeTreatedAsBinary` keeps firing correctly. |
| `test/unit/wireclient.test.mjs` | Update the existing assertion to expect the cleaned `contentType`; add a regression test that legitimate charsets are not stripped. |
| `test/unit/node-wireclient-suite.js` | Same assertion update for the legacy Jaribu suite. |

GET-side mock-server responses in tests still send the suffix (tolerance input) — the assertions verify the library sanitizes it before returning to the caller.

## Backward compatibility

- **Existing files on servers**: still served with `; charset=binary` by the storage backend, but the library now strips it before exposing `contentType` to callers.
- **Apps reading `getFile().contentType`**: previously got `; charset=binary` for legacy files; now get clean mime. If anyone wrote code that expects the suffix, that breaks — but the library already exposes `body` as `ArrayBuffer` vs string for the binary distinction, so the suffix as a signal would be redundant. Risk is low.
- **`shouldBeTreatedAsBinary`**: still public API, still recognizes the suffix when called with the raw header value. Only what's *returned* from `get()` is sanitized.
- **Cachinglayer suite tests**: put items locally with `same/type; charset=binary` and read them back. These exercise the local cache, not the WireClient response path — unaffected.
