### PR TITLE
Allow WebFinger discovery for localhost/private hosts by default

### DIFF
--- a/docs/nodejs.md
+++ b/docs/nodejs.md
@@ -64,7 +64,19 @@ rs-backup is not using remoteStorage.js at all, which you might also
 want to consider as an option when writing non-browser applications.
 :::
 
-## Caveats
+## Other considerations
+
+### Discovery
+
+In most cases, you will want to set `discovery.allowPrivateAddresses` to
+`false` when creating your [RemoteStorage][1] instance.
+
+This setting controls whether WebFinger may target localhost/private-IP hosts.
+It defaults to `true` because cross-origin requests in browsers are already
+gated by the same-origin policy / CORS.  Setting it to `false` in non-browser
+embedders will re-enable webfinger.js's SSRF guard.
+
+### Caveats
 
 - IndexedDB and localStorage are not supported by default in Node.js,
   so the library will fall back to in-memory storage for caching data
@@ -89,3 +101,5 @@ fact cache your data similar to how a browser would do it.
     accounts using the
     [chat-messages](https://www.npmjs.com/package/remotestorage-module-chat-messages)
     module
+
+[1]: ../api/remotestorage/classes/RemoteStorage.html

--- a/docs/nodejs.md
+++ b/docs/nodejs.md
@@ -27,14 +27,14 @@ token that you acquired beforehand:
 remoteStorage.connect('user@example.com', 'abcdef123456')
 ```
 
-This will skip the entire OAuth process, because you did that before in
-some other way, of course.
+This will skip the entire OAuth process in favor of acquiring a token
+beforehand, without the browser redirect.
 
 ## Obtaining a token
 
-For some programs, like e.g. a server daemon, you can usually acquire
-the token from your server manually, and then just configure it for
-example as environment variable, when running your program.
+For some programs, for example a server daemon, you can acquire the token from
+your RS server manually, and then use it from a config file or environment
+variable in your application.
 
 For CLI programs, and if you actually want to integrate the OAuth flow
 in your program, one possible solution is the following:

--- a/src/config.ts
+++ b/src/config.ts
@@ -11,10 +11,7 @@ const config = {
     conflict: true
   },
   cordovaRedirectUri: undefined,
-  // Allow WebFinger discovery to target localhost / private-IP hosts. Defaults
-  // to true because remoteStorage.js runs in browsers, where cross-origin
-  // requests are already gated by the same-origin policy / CORS, so
-  // webfinger.js v3's SSRF protection offers no extra safety here. Set to
+  // Allow WebFinger discovery to target localhost / private-IP hosts. Set to
   // false in non-browser embedders that want the SSRF guard back.
   discoveryAllowPrivateAddresses: true,
   logging: false,

--- a/src/config.ts
+++ b/src/config.ts
@@ -11,16 +11,19 @@ const config = {
     conflict: true
   },
   cordovaRedirectUri: undefined,
-  // Allow WebFinger discovery to target localhost / private-IP hosts. Set to
-  // false in non-browser embedders that want the SSRF guard back.
-  discoveryAllowPrivateAddresses: true,
+  discovery: {
+    // Allow WebFinger discovery to target localhost / private-IP hosts. Set to
+    // false in non-browser embedders that want the SSRF guard back.
+    allowPrivateAddresses: true,
+    // WebFinger lookup timeout, in milliseconds.
+    timeout: 5000
+  },
   logging: false,
   modules: [],
   // the following are not public and will probably be moved away from the
   // default config
   backgroundSyncInterval: 60000,
   disableFeatures: [],
-  discoveryTimeout: 5000,
   isBackground: false,
   requestTimeout: 30000,
   syncInterval: 10000

--- a/src/config.ts
+++ b/src/config.ts
@@ -11,6 +11,12 @@ const config = {
     conflict: true
   },
   cordovaRedirectUri: undefined,
+  // Allow WebFinger discovery to target localhost / private-IP hosts. Defaults
+  // to true because remoteStorage.js runs in browsers, where cross-origin
+  // requests are already gated by the same-origin policy / CORS, so
+  // webfinger.js v3's SSRF protection offers no extra safety here. Set to
+  // false in non-browser embedders that want the SSRF guard back.
+  discoveryAllowPrivateAddresses: true,
   logging: false,
   modules: [],
   // the following are not public and will probably be moved away from the

--- a/src/config.ts
+++ b/src/config.ts
@@ -12,10 +12,7 @@ const config = {
   },
   cordovaRedirectUri: undefined,
   discovery: {
-    // Allow WebFinger discovery to target localhost / private-IP hosts. Set to
-    // false in non-browser embedders that want the SSRF guard back.
     allowPrivateAddresses: true,
-    // WebFinger lookup timeout, in milliseconds.
     timeout: 5000
   },
   logging: false,

--- a/src/discover.ts
+++ b/src/discover.ts
@@ -37,7 +37,13 @@ const Discover = function Discover(userAddress: string): Promise<StorageInfo> {
   const webFinger = new WebFinger({
     tls_only: false,
     uri_fallback: true,
-    request_timeout: config.discoveryTimeout
+    request_timeout: config.discoveryTimeout,
+    // Defaults to true (see config.ts) so that browser apps can discover
+    // localhost / LAN remoteStorage servers, since the same-origin policy /
+    // CORS already gate cross-origin requests there. Non-browser embedders
+    // can opt back into webfinger.js v3's SSRF guard via
+    // `new RemoteStorage({ discoveryAllowPrivateAddresses: false })`.
+    allow_private_addresses: config.discoveryAllowPrivateAddresses
   });
 
   let timer;

--- a/src/discover.ts
+++ b/src/discover.ts
@@ -37,20 +37,15 @@ const Discover = function Discover(userAddress: string): Promise<StorageInfo> {
   const webFinger = new WebFinger({
     tls_only: false,
     uri_fallback: true,
-    request_timeout: config.discoveryTimeout,
-    // Defaults to true (see config.ts) so that browser apps can discover
-    // localhost / LAN remoteStorage servers, since the same-origin policy /
-    // CORS already gate cross-origin requests there. Non-browser embedders
-    // can opt back into webfinger.js v3's SSRF guard via
-    // `new RemoteStorage({ discoveryAllowPrivateAddresses: false })`.
-    allow_private_addresses: config.discoveryAllowPrivateAddresses
+    request_timeout: config.discovery.timeout,
+    allow_private_addresses: config.discovery.allowPrivateAddresses
   });
 
   let timer;
   const timeoutPromise = new Promise<never>((_, reject) => {
     timer = setTimeout(() => {
       reject(new Error('timed out'));
-    }, config.discoveryTimeout);
+    }, config.discovery.timeout);
   });
 
   return Promise.race([

--- a/src/remotestorage.ts
+++ b/src/remotestorage.ts
@@ -160,7 +160,10 @@ enum ApiKeyType {
  *     conflict: true
  *   },
  *   cordovaRedirectUri: undefined,
- *   discoveryAllowPrivateAddresses: true,
+ *   discovery: {
+ *     allowPrivateAddresses: true,
+ *     timeout: 5000
+ *   },
  *   logging: false,
  *   modules: []
  * });
@@ -429,7 +432,17 @@ export class RemoteStorage {
   constructor (cfg?: object) {
     // Initial configuration property settings.
     // TODO use modern JS to merge object properties
-    if (typeof cfg === 'object') { extend(config, cfg); }
+    if (typeof cfg === 'object' && cfg !== null) {
+      // Pull out nested option groups so the shallow `extend` below doesn't
+      // overwrite the whole sub-object when the caller only sets a subset
+      // (e.g. `{ discovery: { timeout: 10 } }` keeps the default
+      // `allowPrivateAddresses`).
+      const { discovery, ...rest } = cfg as { discovery?: object };
+      extend(config, rest);
+      if (discovery && typeof discovery === 'object') {
+        extend(config.discovery, discovery);
+      }
+    }
 
     this.addEvents([
       'ready', 'authing', 'connecting', 'connected', 'disconnected',

--- a/src/remotestorage.ts
+++ b/src/remotestorage.ts
@@ -433,7 +433,7 @@ export class RemoteStorage {
     // Initial configuration property settings.
     // TODO use modern JS to merge object properties
     if (typeof cfg === 'object' && cfg !== null) {
-      // Pull out nested option groups so the shallow `extend` below doesn't
+      // Pull out nested option groups so the `Object.assign` below doesn't
       // overwrite the whole sub-object when the caller only sets a subset
       // (e.g. `{ discovery: { timeout: 10 } }` keeps the default
       // `allowPrivateAddresses`).

--- a/src/remotestorage.ts
+++ b/src/remotestorage.ts
@@ -160,6 +160,7 @@ enum ApiKeyType {
  *     conflict: true
  *   },
  *   cordovaRedirectUri: undefined,
+ *   discoveryAllowPrivateAddresses: true,
  *   logging: false,
  *   modules: []
  * });
@@ -173,6 +174,13 @@ enum ApiKeyType {
  * > [!TIP]
  * > For the change events configuration, you have to set all events
  * > explicitly.  Otherwise it disables the unspecified ones.
+ *
+ * > [!TIP]
+ * > `discoveryAllowPrivateAddresses` controls whether WebFinger discovery may
+ * > target localhost / private-IP storage servers. It defaults to `true`
+ * > because cross-origin requests in browsers are already gated by the
+ * > same-origin policy / CORS. Set it to `false` in non-browser embedders
+ * > that want webfinger.js's SSRF protection back.
  *
  * ## Events
  *

--- a/src/remotestorage.ts
+++ b/src/remotestorage.ts
@@ -175,13 +175,6 @@ enum ApiKeyType {
  * > For the change events configuration, you have to set all events
  * > explicitly.  Otherwise it disables the unspecified ones.
  *
- * > [!TIP]
- * > `discoveryAllowPrivateAddresses` controls whether WebFinger discovery may
- * > target localhost / private-IP storage servers. It defaults to `true`
- * > because cross-origin requests in browsers are already gated by the
- * > same-origin policy / CORS. Set it to `false` in non-browser embedders
- * > that want webfinger.js's SSRF protection back.
- *
  * ## Events
  *
  * You can add event handlers to your `remoteStorage` instance by using the

--- a/src/remotestorage.ts
+++ b/src/remotestorage.ts
@@ -438,9 +438,9 @@ export class RemoteStorage {
       // (e.g. `{ discovery: { timeout: 10 } }` keeps the default
       // `allowPrivateAddresses`).
       const { discovery, ...rest } = cfg as { discovery?: object };
-      extend(config, rest);
+      Object.assign(config, rest);
       if (discovery && typeof discovery === 'object') {
-        extend(config.discovery, discovery);
+        Object.assign(config.discovery, discovery);
       }
     }
 

--- a/src/remotestorage.ts
+++ b/src/remotestorage.ts
@@ -323,6 +323,16 @@ enum ApiKeyType {
  * ### `sync-interval-change`
  *
  * Emitted when the sync interval changes
+ *
+ * @param cfg - Optional configuration object; all properties are optional
+ * @param cfg.discovery - WebFinger discovery settings
+ * @param cfg.discovery.allowPrivateAddresses - Whether WebFinger may target
+ *   localhost / private-IP hosts. Defaults to `true` because cross-origin
+ *   requests in browsers are already gated by the same-origin policy / CORS.
+ *   Set to `false` in non-browser embedders to re-enable webfinger.js's SSRF
+ *   guard.
+ * @param cfg.discovery.timeout - WebFinger lookup timeout in milliseconds
+ *   (default: 5000)
  */
 export class RemoteStorage {
   /**

--- a/src/remotestorage.ts
+++ b/src/remotestorage.ts
@@ -141,7 +141,7 @@ enum ApiKeyType {
 }
 
 /**
- * Create a `remoteStorage` class instance so:
+ * Create a `remoteStorage` class instance:
  *
  * ```js
  * const remoteStorage = new RemoteStorage();
@@ -323,16 +323,6 @@ enum ApiKeyType {
  * ### `sync-interval-change`
  *
  * Emitted when the sync interval changes
- *
- * @param cfg - Optional configuration object; all properties are optional
- * @param cfg.discovery - WebFinger discovery settings
- * @param cfg.discovery.allowPrivateAddresses - Whether WebFinger may target
- *   localhost / private-IP hosts. Defaults to `true` because cross-origin
- *   requests in browsers are already gated by the same-origin policy / CORS.
- *   Set to `false` in non-browser embedders to re-enable webfinger.js's SSRF
- *   guard.
- * @param cfg.discovery.timeout - WebFinger lookup timeout in milliseconds
- *   (default: 5000)
  */
 export class RemoteStorage {
   /**

--- a/test/unit/discover.test.mjs
+++ b/test/unit/discover.test.mjs
@@ -48,6 +48,20 @@ const jrdJimmy = {
   ]
 };
 
+const jrdLocalhost = {
+  "subject": "acct:alice@localhost:8000",
+  "links": [
+    {
+      "rel": "http://tools.ietf.org/id/draft-dejong-remotestorage",
+      "href": "http://localhost:8000/storage/alice",
+      "properties": {
+        "http://remotestorage.io/spec/version": "draft-dejong-remotestorage-13",
+        "http://tools.ietf.org/html/rfc6749#section-4.2": "http://localhost:8000/oauth/alice"
+      }
+    }
+  ]
+};
+
 const jrdJimbo = {
   "subject": "acct:jimmy@kosmos.social",
   "aliases": [
@@ -113,6 +127,36 @@ describe('Webfinger discovery', () => {
         const cachedInfo = JSON.parse(localStorage.getItem('remotestorage:discover')).cache;
         expect(cachedInfo['jimmy@kosmos.org'].href).to.equal('https://storage.kosmos.org/jimmy');
       });
+    });
+
+    after(() => fetchMock.reset());
+  });
+
+  describe('localhost / private addresses (regression for #1384)', () => {
+    before(() => {
+      fetchMock.mock(
+        'http://localhost:8000/.well-known/webfinger?resource=acct:alice@localhost:8000',
+        { status: 200, body: jrdLocalhost, headers: {
+          'Content-Type': 'application/jrd+json; charset=utf-8'
+        }},
+      );
+    });
+
+    it("resolves storage info for a localhost address by default", async () => {
+      const info = await Discover('alice@localhost:8000');
+      expect(info.href).to.equal('http://localhost:8000/storage/alice');
+      expect(info.authURL).to.equal('http://localhost:8000/oauth/alice');
+    });
+
+    it("rejects localhost addresses when discoveryAllowPrivateAddresses is false", async () => {
+      const previous = config.discoveryAllowPrivateAddresses;
+      config.discoveryAllowPrivateAddresses = false;
+      try {
+        // Use a fresh address so the in-module cache does not short-circuit the lookup.
+        await expect(Discover('bob@localhost:9000')).to.be.rejectedWith(/private or internal addresses/);
+      } finally {
+        config.discoveryAllowPrivateAddresses = previous;
+      }
     });
 
     after(() => fetchMock.reset());

--- a/test/unit/discover.test.mjs
+++ b/test/unit/discover.test.mjs
@@ -94,13 +94,13 @@ const jrdJimbo = {
 describe('Webfinger discovery', () => {
   before(() => {
     config.requestTimeout = 500;
-    config.discoveryTimeout = 500;
+    config.discovery.timeout = 500;
   });
 
   after(() => {
     localStorage.clear();
     config.requestTimeout = 30000;
-    config.discoveryTimeout = 5000;
+    config.discovery.timeout = 5000;
   });
 
   describe('successful lookup', () => {
@@ -148,14 +148,14 @@ describe('Webfinger discovery', () => {
       expect(info.authURL).to.equal('http://localhost:8000/oauth/alice');
     });
 
-    it("rejects localhost addresses when discoveryAllowPrivateAddresses is false", async () => {
-      const previous = config.discoveryAllowPrivateAddresses;
-      config.discoveryAllowPrivateAddresses = false;
+    it("rejects localhost addresses when discovery.allowPrivateAddresses is false", async () => {
+      const previous = config.discovery.allowPrivateAddresses;
+      config.discovery.allowPrivateAddresses = false;
       try {
         // Use a fresh address so the in-module cache does not short-circuit the lookup.
         await expect(Discover('bob@localhost:9000')).to.be.rejectedWith(/private or internal addresses/);
       } finally {
-        config.discoveryAllowPrivateAddresses = previous;
+        config.discovery.allowPrivateAddresses = previous;
       }
     });
 

--- a/test/unit/remotestorage.test.mjs
+++ b/test/unit/remotestorage.test.mjs
@@ -5,6 +5,7 @@ import chaiAsPromised from 'chai-as-promised';
 import sinon from 'sinon';
 import fetchMock from 'fetch-mock';
 
+import config from '../../build/config.js';
 import Dropbox from '../../build/dropbox.js';
 import { EventHandling } from '../../build/eventhandling.js';
 import { RemoteStorage } from '../../build/remotestorage.js';
@@ -39,6 +40,27 @@ describe("RemoteStorage", function() {
     this.rs = undefined;
     fetchMock.reset();
     sinon.reset();
+  });
+
+  describe('constructor config', function() {
+    it("merges nested `discovery` options with the defaults", function() {
+      const previousTimeout = config.discovery.timeout;
+      const previousAllow = config.discovery.allowPrivateAddresses;
+      try {
+        // Setting only `timeout` must not clobber the default `allowPrivateAddresses`.
+        new RemoteStorage({ cache: false, discovery: { timeout: 1234 } }).disconnect();
+        expect(config.discovery.timeout).to.equal(1234);
+        expect(config.discovery.allowPrivateAddresses).to.equal(previousAllow);
+
+        // Setting only `allowPrivateAddresses` must not clobber `timeout`.
+        new RemoteStorage({ cache: false, discovery: { allowPrivateAddresses: false } }).disconnect();
+        expect(config.discovery.timeout).to.equal(1234);
+        expect(config.discovery.allowPrivateAddresses).to.equal(false);
+      } finally {
+        config.discovery.timeout = previousTimeout;
+        config.discovery.allowPrivateAddresses = previousAllow;
+      }
+    });
   });
 
   describe('#addModule', function() {
@@ -84,7 +106,7 @@ describe("RemoteStorage", function() {
 
       this.rs = new RemoteStorage({
         cache: false,
-        discoveryTimeout: 10
+        discovery: { timeout: 10 }
       });
 
       sinon.stub(this.rs, 'authorize');


### PR DESCRIPTION
## Problem

`rs.connect("user@localhost:8000")` (and any address whose host resolves to a localhost / private IP) fails immediately with `WebFingerError: private or internal addresses are not allowed`, before any HTTP request is made.

This is a regression introduced by the webfinger.js v3 upgrade in #1370 (commit 490b5f7) and ships in `2.0.0-beta.9`. webfinger.js v3 added an `allow_private_addresses` config option that defaults to `false`, and `WebFinger#resolveAndValidateHost` now throws on any host matching its private/localhost regex *before* attempting the WebFinger lookup.

That breaks:

- Local development against any RS server on `localhost`.
- Self-hosted users running their RS server on a private LAN address (`192.168.x.x`, `10.x.x.x`, etc.).
- E2E test suites that drive the real OAuth flow against a Dockerized RS server (which is how we hit it — see [silverbucket/inbox-rs#105](https://github.com/silverbucket/inbox-rs/pull/105)).

## Fix

The SSRF protection makes sense for server-side webfinger callers (the original concern in [silverbucket/webfinger.js#65](https://github.com/silverbucket/webfinger.js/issues/65)), but remoteStorage.js runs in browsers, where cross-origin requests are already gated by the same-origin policy / CORS — the flag's threat model doesn't apply there and only blocks legitimate localhost / LAN development.

This PR takes option 2 from the issue: a new `discovery` config object, defaulting to `true` so beta.9's behaviour is restored, with non-browser embedders able to opt back into the SSRF guard.

```js
// Browser apps (default): localhost / LAN discovery works
const remoteStorage = new RemoteStorage();

// Non-browser embedder that wants the SSRF guard back
const remoteStorage = new RemoteStorage({
  discovery: {
    allowPrivateAddresses: false
  }
});
```

## Breaking changes

  - `discoveryTimeout` (a flat top-level constructor option added in beta.9) has
    been replaced by `discovery.timeout` inside the new `discovery` config object.
    Update any existing usage:

    ```js
    // before
    new RemoteStorage({ discoveryTimeout: 10000 });

    // after
    new RemoteStorage({ discovery: { timeout: 10000 } });

Closes #1384.

