### PR TITLE
Fix Dropbox disconnect

### DIFF
--- a/src/dropbox.ts
+++ b/src/dropbox.ts
@@ -243,6 +243,7 @@ class Dropbox extends RemoteBase implements Remote {
       this.connected = false;
       if (hasLocalStorage) {
         localStorage.removeItem(SETTINGS_KEY);
+        localStorage.removeItem(`${SETTINGS_KEY}:shares`);
       }
       this.rs.setBackend(undefined);
     };

--- a/src/remotestorage.ts
+++ b/src/remotestorage.ts
@@ -728,6 +728,7 @@ export class RemoteStorage {
         href: null,
         storageApi: null,
         token: null,
+        refreshToken: null,
         properties: null
       });
     }

--- a/test/unit/dropbox.test.mjs
+++ b/test/unit/dropbox.test.mjs
@@ -304,6 +304,32 @@ describe('Dropbox backend', () => {
     });
   });
 
+  describe("disconnect", () => {
+    it("removes SETTINGS_KEY and the shares cache from localStorage", async () => {
+      const sharesKey = `${SETTINGS_KEY}:shares`;
+      localStorage.setItem(sharesKey, JSON.stringify({ '/public/foo.txt': 'https://db.tt/link' }));
+
+      await dropbox.configure({ userAddress: null, token: null, refreshToken: null });
+
+      expect(localStorage.getItem(SETTINGS_KEY)).to.be.null;
+      expect(localStorage.getItem(sharesKey)).to.be.null;
+    });
+
+    it("resets credentials and connection state in RemoteStorage", async () => {
+      rs.remote = dropbox;
+      rs.setBackend('dropbox');
+      expect(dropbox.refreshToken).to.equal(REFRESH_TOKEN);
+
+      rs.disconnect();
+
+      expect(dropbox.connected).to.be.false;
+      expect(dropbox.refreshToken).to.be.null;
+      expect(dropbox.token).to.be.null;
+      expect(dropbox.userAddress).to.be.null;
+      expect(rs.backend).to.be.undefined;
+    });
+  });
+
   describe("get", () => {
     it('rejects a promise if not connected', async () => {
       dropbox.connected = false;


### PR DESCRIPTION
* Delete the refresh token, so that disconnect works properly
* Delete the cache for mapping filenames to public URLs

fixes #1391