### PR TITLE
Secure CI workflows against supply-chain attacks

### DIFF
--- a/.github/workflows/notify-website-repo.yml
+++ b/.github/workflows/notify-website-repo.yml
@@ -5,12 +5,14 @@ on:
     branches:
       - master
 
+permissions: {}
+
 jobs:
   notify:
     runs-on: ubuntu-latest
     steps:
       - name: Repository Dispatch
-        uses: peter-evans/repository-dispatch@v2
+        uses: peter-evans/repository-dispatch@28959ce8df70de7be546dd1250a005dd32156697 # v4.0.1
         with:
           token: ${{ secrets.RS_DISPATCH_PAT }}
           repository: remotestorage/website

--- a/.github/workflows/release-drafter.yml
+++ b/.github/workflows/release-drafter.yml
@@ -14,6 +14,6 @@ jobs:
   update_release_draft:
     runs-on: ubuntu-latest
     steps:
-      - uses: release-drafter/release-drafter@v7
+      - uses: release-drafter/release-drafter@ed4bc48ec97379be2258e7b7ac2624a3e26ab809   # v7.4.0
         with:
           config-name: release-drafter.yml # the default, loads '.github/release-drafter.yml'

--- a/.github/workflows/test-and-lint.yml
+++ b/.github/workflows/test-and-lint.yml
@@ -16,7 +16,7 @@ jobs:
     strategy:
       matrix:
         # Support LTS versions based on https://nodejs.org/en/about/releases/
-        node-version: ['20', '22', '24']
+        node-version: ['22', '24', '26']
       fail-fast: false
     steps:
       - uses: actions/checkout@v6.0.2

--- a/.github/workflows/test-and-lint.yml
+++ b/.github/workflows/test-and-lint.yml
@@ -6,6 +6,8 @@ on:
   pull_request:
     branches: [ master, stable ]
 
+permissions: {}
+
 jobs:
   build:
     name: node.js
@@ -18,6 +20,8 @@ jobs:
       fail-fast: false
     steps:
       - uses: actions/checkout@v6.0.2
+        with:
+          persist-credentials: false
       - name: Use Node.js ${{ matrix.node-version }}
         uses: actions/setup-node@v6.3.0
         with:


### PR DESCRIPTION
1.  CI: removes unneeded permissions
2. CI: pins version of 3rd-party actions
3. CI: drops Node.js v20, adds Node.js v26

To test: push branch to the master branch of your personal repo, in GitHub Actions tab, observe that test-and-lint and release-drafter complete successfully, and notify-website-repo only fails because "Parameter token or opts.auth is required"